### PR TITLE
Add NOTICE file with patent boundary

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0.
 
 PATENT NOTICE
 
-This license does not cover self-developing graph systems. Graph structures
+This license does not cover self-developing graph systems. Graph structures or substrates
 that modify themselves during execution are the subject of U.S. patent
 application 19/575,491. See https://github.com/Xepayac/XEPAYAC_LLC for
 AGPL 3.0 and commercial licensing.


### PR DESCRIPTION
## Summary
- Adds Apache 2.0 NOTICE file with patent boundary statement
- Self-modification of graph structures during execution is patent 19/575,491 territory, not covered by this Apache 2.0 license
- Apache 2.0 Section 4d requires derivative works to preserve NOTICE files — this propagates automatically

## Test plan
- [x] NOTICE file present and correctly formatted
- [ ] Human review of wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)