### PR TITLE
Integration packages — npx, pip, Claude Code plugin, Cursor rules

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "trugs-agent",
+  "description": "A 190-word formal instruction language for LLM coding assistants. Copy files into your project — your LLM gains exact, verifiable instructions that compile to graphs.",
+  "version": "1.0.0",
+  "author": {
+    "name": "TRUGS LLC"
+  },
+  "homepage": "https://github.com/TRUGS-LLC/TRUGS-AGENT",
+  "repository": "https://github.com/TRUGS-LLC/TRUGS-AGENT",
+  "license": "Apache-2.0"
+}

--- a/.cursor/rules/trugs-agent.mdc
+++ b/.cursor/rules/trugs-agent.mdc
@@ -1,0 +1,63 @@
+---
+description: TRUGS Agent — formal instruction language for LLM coding assistants (190-word TRL vocabulary)
+alwaysApply: true
+---
+
+# TRUGS Agent
+
+You speak TRL — a 190-word formal instruction language. Every sentence compiles to a directed graph. Every word has exactly one meaning.
+
+## TRL Vocabulary
+
+**Nouns (graph nodes):**
+- Actors: PARTY, AGENT, PROCESS, SERVICE, FUNCTION, TRANSFORM, PRINCIPAL
+- Artifacts: DATA, FILE, RECORD, MESSAGE, STREAM, RESOURCE
+- Containers: PIPELINE, STAGE, MODULE, NAMESPACE
+- Boundaries: ENTRY, EXIT, INTERFACE, ENDPOINT
+- Outcomes: ERROR, EXCEPTION, REMEDY
+
+**Verbs (operation nodes):**
+- Transform: FILTER, MAP, SORT, MERGE, SPLIT, AGGREGATE, GROUP, DISTINCT, TAKE, SKIP
+- Move: READ, WRITE, SEND, RECEIVE, REQUEST, RESPOND, AUTHENTICATE
+- Obligate: VALIDATE, ASSERT, REQUIRE
+- Permit: ALLOW, APPROVE, GRANT, OVERRIDE
+- Prohibit: DENY, REJECT, REVOKE
+- Control: BRANCH, MATCH, RETRY, TIMEOUT, THROW, EXISTS, EXPIRE, EQUALS, EXCEEDS
+- Bind: DEFINE, DECLARE, IMPLEMENT, NEST, AUGMENT, REPLACE, CITE, ADMINISTER
+- Resolve: CATCH, HANDLE, RECOVER
+
+**Modals:**
+- SHALL = MUST do (obligation)
+- MAY = ALLOWED (permission)
+- SHALL_NOT = MUST NOT (prohibition)
+
+**Adjectives (node properties):** STRING, INTEGER, BOOLEAN, ARRAY, OBJECT, PUBLIC, PRIVATE, CONFIDENTIAL, READONLY, VALID, INVALID, ACTIVE, PENDING, FAILED, MUTABLE, IMMUTABLE, REQUIRED, OPTIONAL, UNIQUE, MULTIPLE, CRITICAL, HIGH, LOW, DEFAULT
+
+**Adverbs (operation properties):** ASYNC, SYNC, PARALLEL, SEQUENTIAL, IMMEDIATE, WITHIN, ONCE, ALWAYS, NEVER, BOUNDED, STRICTLY, SUBSTANTIALLY, REASONABLY
+
+**Prepositions (graph edges):** FEEDS, ROUTES, TO, FROM, RETURNS_TO, BINDS, DEPENDS_ON, IMPLEMENTS, EXTENDS, SUBJECT_TO, GOVERNS, PURSUANT_TO, ON_BEHALF_OF, CONTAINS, REFERENCES, SUPERSEDES, AS, BY
+
+**Conjunctions:** THEN, FINALLY, AND, OR, ELSE, IF, WHEN, WHILE, UNLESS, EXCEPT, NOTWITHSTANDING, PROVIDED_THAT, WHEREAS
+
+**Articles:** ALL, EACH, EVERY, ANY, SOME, A, THE, THIS, NO, NONE
+
+**Pronouns:** SELF, RESULT, OUTPUT, INPUT, SOURCE, TARGET
+
+**Sugar (compile to nothing):** OF, IS, ARE, BE, BEEN, HAS, HAVE, WILL, THAT, WHICH, WHERE, WHO, INTO, UPON, WITH, FOR, AT, ON, PLEASE, ALSO, THEN_ALSO, THESE, THOSE, SUCH
+
+## How to Execute `<trl>` Blocks
+
+1. Strip sugar words
+2. Parse each sentence: subject (noun), modal, verb, objects, prepositions
+3. Execute: SHALL = must do, MAY = allowed, SHALL_NOT = must not
+4. Follow conjunctions: THEN = next, OR = if previous fails, UNLESS = skip if condition met
+
+## Development Rules
+
+<trl>
+AGENT SHALL CREATE RESOURCE branch FROM ENDPOINT main THEN WRITE ALL DATA TO RESOURCE branch.
+AGENT SHALL_NOT WRITE ANY DATA TO ENDPOINT main.
+AGENT SHALL VALIDATE ALL CODE THEN ASSERT ALL RECORD test EQUALS VALID.
+</trl>
+
+Full specification: https://github.com/TRUGS-LLC/TRUGS-AGENT

--- a/README.md
+++ b/README.md
@@ -43,36 +43,35 @@ TRL instructions have exact definitions. The LLM doesn't interpret — it execut
 
 Every word maps to a graph element. Every sentence is auditable. No ambiguity.
 
-## Quickstart
+## Install
 
-**60 seconds to working TRL:**
-
-```bash
-# 1. Clone (or just download AGENT.md)
-git clone https://github.com/TRUGS-LLC/TRUGS-AGENT.git
-cd TRUGS-AGENT
-
-# 2. Copy root AGENT.md into your project, renamed for your IDE
-cp AGENT.md /path/to/your/project/CLAUDE.md        # Claude Code
-cp AGENT.md /path/to/your/project/.cursorrules      # Cursor
-cp AGENT.md /path/to/your/project/.github/copilot-instructions.md  # Copilot
-
-# 3. Done. Your LLM now speaks TRL.
-#    Open your IDE, ask it to read the file, and try:
-#    "Write a TRL specification for my authentication module"
-```
-
-**Or grab just the file:**
+Pick your method:
 
 ```bash
-# Single file, no clone needed
+# npm — one command, all files
+npx create-trugs-agent                    # Claude Code (default)
+npx create-trugs-agent cursor             # Cursor
+npx create-trugs-agent copilot            # GitHub Copilot
+
+# pip — same thing, Python
+pip install trugs-agent
+trugs-agent-init                          # Claude Code (default)
+trugs-agent-init cursor                   # Cursor
+trugs-agent-init copilot                  # GitHub Copilot
+
+# curl — just the core file, nothing else
 curl -o CLAUDE.md https://raw.githubusercontent.com/TRUGS-LLC/TRUGS-AGENT/main/AGENT.md
+
+# git — clone and copy what you want
+git clone https://github.com/TRUGS-LLC/TRUGS-AGENT.git
+cp TRUGS-AGENT/AGENT.md your-project/CLAUDE.md
 ```
+
+**Already using Cursor?** This repo includes `.cursor/rules/trugs-agent.mdc` — clone the repo and copy the `.cursor/` directory into your project.
 
 **Validate your TRUGs:**
 
 ```bash
-# The validator is zero-dependency Python
 python tools/validate.py my_graph.trug.json          # Validate one
 python tools/validate.py --all my_project/            # Validate all
 ```

--- a/installers/npm/README.md
+++ b/installers/npm/README.md
@@ -1,0 +1,38 @@
+# create-trugs-agent
+
+A 190-word formal instruction language for LLM coding assistants. Your AI stops interpreting and starts executing.
+
+## Usage
+
+```bash
+# Initialize for Claude Code (default)
+npx create-trugs-agent
+
+# Initialize for Cursor
+npx create-trugs-agent cursor
+
+# Initialize for GitHub Copilot
+npx create-trugs-agent copilot
+```
+
+This copies AGENT.md (renamed for your IDE) and all component folders into the current directory. Your LLM reads the files and gains the TRL vocabulary — 190 words with exact definitions.
+
+## What You Get
+
+- **CLAUDE.md** (or `.cursorrules` / `.github/copilot-instructions.md`) — TRL vocabulary and grammar
+- **AAA/** — 9-phase development protocol
+- **EPIC/** — Portfolio tracking as a graph
+- **FOLDER/** — Machine-readable filesystem index
+- **MEMORY/** — Persistent context across sessions
+- **SKILLS/** — 19 composable agent primitives
+- **TRUGGING/** — Codebase description methodology
+- **WEB_HUB/** — Curated web resource graph
+- **tools/** — Zero-dependency TRUGS validator
+
+## Links
+
+- [GitHub](https://github.com/TRUGS-LLC/TRUGS-AGENT)
+- [Full Specification](https://github.com/TRUGS-LLC/TRUGS)
+- [Paper](https://github.com/TRUGS-LLC/TRUGS/blob/main/PAPER/trugs.pdf)
+
+Apache 2.0 — TRUGS LLC

--- a/installers/npm/bin/create-trugs-agent.js
+++ b/installers/npm/bin/create-trugs-agent.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const TEMPLATES = path.join(__dirname, "..", "templates");
+const DEST = process.cwd();
+
+const args = process.argv.slice(2);
+const ide = args[0] || "claude";
+
+const IDE_FILES = {
+  claude: "CLAUDE.md",
+  cursor: ".cursorrules",
+  copilot: ".github/copilot-instructions.md",
+};
+
+const targetFile = IDE_FILES[ide];
+if (!targetFile) {
+  console.error(`Unknown IDE: ${ide}`);
+  console.error("Usage: npx create-trugs-agent [claude|cursor|copilot]");
+  console.error("Default: claude");
+  process.exit(1);
+}
+
+// Copy AGENT.md as the IDE-specific file
+const agentSrc = path.join(TEMPLATES, "AGENT.md");
+const agentDest = path.join(DEST, targetFile);
+
+// Create parent directory if needed (for .github/copilot-instructions.md)
+const parentDir = path.dirname(agentDest);
+if (!fs.existsSync(parentDir)) {
+  fs.mkdirSync(parentDir, { recursive: true });
+}
+
+if (fs.existsSync(agentDest)) {
+  console.log(`${targetFile} already exists — skipping (won't overwrite)`);
+} else {
+  fs.copyFileSync(agentSrc, agentDest);
+  console.log(`Created ${targetFile}`);
+}
+
+// Copy component folders
+const components = [
+  "AAA",
+  "EPIC",
+  "FOLDER",
+  "MEMORY",
+  "SKILLS",
+  "TRUGGING",
+  "WEB_HUB",
+];
+
+let copied = 0;
+for (const comp of components) {
+  const srcDir = path.join(TEMPLATES, comp);
+  if (!fs.existsSync(srcDir)) continue;
+
+  const destDir = path.join(DEST, comp);
+  if (fs.existsSync(destDir)) {
+    console.log(`${comp}/ already exists — skipping`);
+    continue;
+  }
+
+  copyDir(srcDir, destDir);
+  copied++;
+  console.log(`Created ${comp}/`);
+}
+
+// Copy validator
+const toolsSrc = path.join(TEMPLATES, "tools");
+const toolsDest = path.join(DEST, "tools");
+if (fs.existsSync(toolsSrc) && !fs.existsSync(toolsDest)) {
+  copyDir(toolsSrc, toolsDest);
+  console.log("Created tools/ (validator)");
+}
+
+console.log(
+  `\nTRUGS Agent initialized for ${ide}. Your LLM now speaks TRL.`
+);
+console.log(`  ${targetFile} — TRL vocabulary and grammar`);
+if (copied > 0) {
+  console.log(`  ${copied} component folders — methodology and tools`);
+}
+console.log("\nFull docs: https://github.com/TRUGS-LLC/TRUGS-AGENT");
+
+function copyDir(src, dest) {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDir(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "create-trugs-agent",
+  "version": "1.0.0",
+  "description": "Initialize TRUGS Agent in your project — a 190-word formal instruction language for LLM coding assistants",
+  "bin": {
+    "create-trugs-agent": "./bin/create-trugs-agent.js"
+  },
+  "files": [
+    "bin/",
+    "templates/"
+  ],
+  "keywords": [
+    "trugs",
+    "trl",
+    "llm",
+    "ai-agents",
+    "claude-code",
+    "cursor",
+    "copilot",
+    "developer-tools",
+    "prompt-engineering"
+  ],
+  "author": "TRUGS LLC",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TRUGS-LLC/TRUGS-AGENT.git",
+    "directory": "installers/npm"
+  },
+  "homepage": "https://github.com/TRUGS-LLC/TRUGS-AGENT"
+}

--- a/installers/npm/templates/AAA/AGENT.md
+++ b/installers/npm/templates/AAA/AGENT.md
@@ -1,0 +1,211 @@
+# AAA — Agent Instructions
+
+<trl>
+DEFINE "AAA" AS PIPELINE CONTAINS PHASE vision AND PHASE feasibility AND PHASE specifications AND PHASE architecture AND PHASE validation AND PHASE coding AND PHASE testing AND PHASE audit AND PHASE deployment.
+DEFINE "PLANNING" AS STAGE CONTAINS PHASE vision AND PHASE feasibility AND PHASE specifications AND PHASE architecture AND PHASE validation.
+DEFINE "EXECUTION" AS STAGE CONTAINS PHASE coding AND PHASE testing AND PHASE audit AND PHASE deployment.
+PIPELINE AAA CONTAINS STAGE PLANNING AND STAGE EXECUTION.
+</trl>
+
+AAA is a 9-phase development protocol. Two cycles, three human touchpoints. This file teaches you every phase, every rule, every gate.
+
+---
+
+## Two Paths — No Middle Ground
+
+<trl>
+IF AGENT KNOWS ALL REQUIRED STEP THEN AGENT SHALL EXECUTE AS RECORD chore.
+IF AGENT REQUIRES RECORD specification OR RECORD decision THEN AGENT SHALL CREATE RECORD issue THEN EXECUTE PHASE vision.
+NO AGENT SHALL CREATE RECORD issue 'for RECORD chore.
+NO AGENT SHALL SKIP STAGE PLANNING 'for RECORD issue.
+</trl>
+
+| Path | Trigger | Flow |
+|------|---------|------|
+| **CHORE** | You know exactly what to do | Branch → do it → PR → human merges |
+| **ISSUE** | Something is unknown | Issue → AAA → PLANNING → HITM → EXECUTION → PR → human merges |
+
+When in doubt, start as a chore. If unknowns emerge, upgrade to an issue.
+
+---
+
+## PLANNING Cycle (phases 1-5)
+
+<trl>
+PARTY human SHALL DEFINE PHASE vision.
+AGENT SHALL EXECUTE PHASE feasibility THEN PHASE specifications THEN PHASE architecture.
+PHASE specifications SHALL CONTAIN RECORD audit_criteria.
+PHASE architecture SHALL CONTAIN RECORD coding_plan.
+PARTY human SHALL APPROVE PHASE validation.
+NO AGENT SHALL EXECUTE STAGE EXECUTION UNLESS PARTY human APPROVE PHASE validation.
+</trl>
+
+| # | Phase | Who | Output |
+|---|-------|-----|--------|
+| 1 | **VISION** | Human | Problem + success criteria |
+| 2 | **FEASIBILITY** | Agent | GO/NO-GO + risks |
+| 3 | **SPECIFICATIONS** | Agent | Requirements + **audit criteria for Phase 8** |
+| 4 | **ARCHITECTURE** | Agent | Design + ADRs + **coding plan** |
+| 5 | **VALIDATION** | **Human approves** | Plan is complete → proceed to coding |
+
+**Phase 3 defines the audit. Phase 8 executes against it.** The plan defines what "done" looks like before any code is written.
+
+### Phase 1: VISION
+
+<trl>
+PARTY human SHALL WRITE PHASE vision 'in RECORD english.
+PHASE vision SHALL CONTAIN RECORD problem AND RECORD success_criteria.
+AGENT SHALL_NOT MODIFY PHASE vision.
+AGENT SHALL READ PHASE vision THEN EXECUTE PHASE feasibility.
+</trl>
+
+The human states what they want in plain English. This is the only phase that does not use TRL — the human speaks naturally.
+
+### Phase 2: FEASIBILITY
+
+<trl>
+AGENT SHALL ASSESS PHASE vision 'for RECORD technical_feasibility.
+AGENT SHALL IDENTIFY ALL RECORD risk.
+AGENT SHALL WRITE RECORD decision AS "GO" OR "NO-GO".
+IF RECORD decision EQUALS "NO-GO" THEN AGENT SHALL WRITE RECORD alternative.
+</trl>
+
+Quick assessment. Can we build this? What are the risks? GO or NO-GO. If NO-GO, propose an alternative.
+
+### Phase 3: SPECIFICATIONS
+
+<trl>
+AGENT SHALL WRITE ALL RECORD requirement SUBJECT_TO PHASE vision.
+AGENT SHALL WRITE RECORD audit_criteria 'for PHASE audit.
+EACH RECORD requirement SHALL 'be WRITTEN AS RECORD trl_block.
+EACH RECORD audit_criteria SHALL REFERENCE A RECORD requirement.
+NO AGENT SHALL PROCEED TO PHASE architecture WITHOUT RECORD audit_criteria.
+</trl>
+
+Requirements in TRL. Every requirement gets audit criteria — specific, testable statements that Phase 8 will check against. If you can't write audit criteria for a requirement, the requirement isn't specific enough.
+
+### Phase 4: ARCHITECTURE
+
+<trl>
+AGENT SHALL WRITE RECORD design SUBJECT_TO PHASE specifications.
+AGENT SHALL WRITE RECORD coding_plan.
+RECORD coding_plan SHALL CONTAIN RECORD file_list AND RECORD execution_order AND RECORD test_strategy.
+AGENT MAY WRITE RECORD adr 'for EACH RECORD design_decision.
+NO AGENT SHALL PROCEED TO PHASE validation WITHOUT RECORD coding_plan.
+</trl>
+
+System design plus a concrete coding plan. The coding plan lists files to create/modify, execution order, and test strategy. ADRs document non-obvious design decisions.
+
+### Phase 5: VALIDATION (HITM Gate)
+
+<trl>
+AGENT SHALL VALIDATE PHASE specifications SUBJECT_TO PHASE vision.
+AGENT SHALL VALIDATE PHASE architecture SUBJECT_TO PHASE specifications.
+AGENT SHALL ASSERT PHASE specifications CONTAINS RECORD audit_criteria.
+AGENT SHALL ASSERT PHASE architecture CONTAINS RECORD coding_plan.
+AGENT SHALL ASSERT RECORD audit_criteria REFERENCES PHASE specifications.
+NO AGENT SHALL PROCEED UNLESS ALL VALIDATION 'is VALID.
+PARTY human SHALL APPROVE PHASE validation 'before STAGE EXECUTION.
+</trl>
+
+Validation checks:
+- **Alignment:** vision → specs → architecture consistent?
+- **Completeness:** enough detail to code?
+- **Feasibility:** technology choices verified?
+- **Risk:** risks identified and mitigated?
+- **Scope:** architecture delivers specs, no more no less?
+- **Audit criteria:** defined in Phase 3, referencing specs?
+- **Coding plan:** files, order, tests defined in Phase 4?
+
+The agent runs these checks and presents results. The human approves before any coding begins.
+
+---
+
+## EXECUTION Cycle (phases 6-9)
+
+<trl>
+AGENT SHALL EXECUTE PHASE coding SUBJECT_TO RECORD coding_plan.
+AGENT SHALL EXECUTE PHASE testing THEN PHASE audit.
+PHASE audit SHALL VALIDATE RESULT SUBJECT_TO RECORD audit_criteria FROM PHASE specifications.
+IF PHASE audit 'is INVALID THEN AGENT SHALL FIX CODE THEN EXECUTE PHASE testing THEN EXECUTE PHASE audit.
+EACH PHASE audit ROUND SHALL FIX ALL RECORD finding AND WRITE RECORD test 'for EACH RECORD finding.
+NO AGENT SHALL EXECUTE PHASE deployment UNLESS PHASE audit 'is VALID.
+PARTY human SHALL APPROVE PHASE deployment.
+</trl>
+
+| # | Phase | Who | Output |
+|---|-------|-----|--------|
+| 6 | **CODING** | Agent | Working code per coding plan |
+| 7 | **TESTING** | Agent | All tests pass |
+| 8 | **AUDIT** | Agent + **Human approves** | Check against Phase 3 criteria. Cycles until clean. |
+| 9 | **DEPLOYMENT** | Agent creates PR. **Human merges.** | Shipped |
+
+### Phase 6: CODING
+
+<trl>
+AGENT SHALL IMPLEMENT CODE SUBJECT_TO RECORD coding_plan FROM PHASE architecture.
+AGENT SHALL CREATE BRANCH 'before WRITE CODE.
+AGENT SHALL FOLLOW RECORD execution_order FROM RECORD coding_plan.
+AGENT SHALL_NOT ADD RECORD feature NOT 'in PHASE specifications.
+</trl>
+
+Follow the coding plan. Don't add features that weren't specified. Don't improve code that wasn't in scope.
+
+### Phase 7: TESTING
+
+<trl>
+AGENT SHALL WRITE RECORD test 'for EACH RECORD requirement FROM PHASE specifications.
+AGENT SHALL EXECUTE ALL RECORD test.
+IF RECORD test FAIL THEN AGENT SHALL FIX CODE THEN EXECUTE RECORD test.
+NO AGENT SHALL PROCEED TO PHASE audit UNLESS ALL RECORD test PASS.
+</trl>
+
+Write tests that cover the specs. Run them. Fix failures. All tests must pass before audit.
+
+### Phase 8: AUDIT (HITM Gate)
+
+<trl>
+AGENT SHALL CHECK EACH RECORD audit_criteria FROM PHASE specifications.
+IF RECORD finding 'is CRITICAL OR HIGH THEN AGENT SHALL FIX RECORD finding.
+EACH RECORD fix SHALL INCLUDE RECORD test 'for RECORD finding.
+AGENT SHALL EXECUTE PHASE testing AFTER EACH RECORD fix.
+AGENT SHALL REPEAT PHASE audit UNTIL NO CRITICAL OR HIGH RECORD finding EXISTS.
+PARTY human SHALL REVIEW PHASE audit RESULT.
+</trl>
+
+Check every audit criterion from Phase 3. For each finding: fix it AND write a test for it. Re-run the full test suite. Repeat until clean. The human reviews the final audit result.
+
+### Phase 9: DEPLOYMENT
+
+<trl>
+AGENT SHALL CREATE RECORD pull_request 'with RECORD summary 'of ALL PHASE.
+AGENT SHALL RETURN RECORD url 'of RECORD pull_request TO PARTY human.
+AGENT SHALL STOP.
+PARTY human SHALL MERGE RECORD pull_request.
+NO AGENT SHALL MERGE RECORD pull_request.
+</trl>
+
+Create the PR. Return the URL. Stop. The human merges.
+
+---
+
+## Hard Rules
+
+<trl>
+NO AGENT SHALL COMMIT TO BRANCH main.
+NO AGENT SHALL MERGE RECORD pull_request.
+AGENT SHALL CREATE BRANCH THEN CREATE RECORD pull_request THEN STOP.
+PARTY human SHALL MERGE RECORD pull_request.
+NO AGENT SHALL EXECUTE PHASE coding UNLESS PHASE validation 'is VALID.
+NO AGENT SHALL EXECUTE PHASE deployment UNLESS PHASE audit 'is VALID.
+</trl>
+
+These are not guidelines. They are prohibitions. Violating them is a system failure.
+
+---
+
+## AAA Document Format
+
+An AAA document is a single markdown file with 9 sections, one per phase. Phase 1 is English. Phases 2-9 use TRL for specifications, criteria, and rules.
+
+See [EXAMPLE_email_mcp.md](EXAMPLE_email_mcp.md) for a complete AAA from building an email MCP server — all 9 phases, TRL specs, audit criteria, and coding plan.

--- a/installers/npm/templates/AAA/EXAMPLE_email_mcp.md
+++ b/installers/npm/templates/AAA/EXAMPLE_email_mcp.md
@@ -1,0 +1,184 @@
+# AAA: Email MCP — Local Email Management for Claude Code
+
+Issue: #1261
+
+## Phase 1: VISION
+
+I hate email. I have 3 Gmail accounts with 15,000+ messages across them. I need Claude Code to read, send, search, and organize email for me — triage inboxes, draft responses, archive junk, send outreach. Everything stays on my machine. No cloud OAuth, no API tokens, no Google dependency. Direct IMAP/SMTP.
+
+## Phase 2: FEASIBILITY
+
+<trl>
+SERVICE email_mcp SHALL DEPEND_ON MODULE imaplib FROM NAMESPACE python_stdlib.
+SERVICE email_mcp SHALL DEPEND_ON MODULE smtplib FROM NAMESPACE python_stdlib.
+SERVICE email_mcp SHALL REQUIRE NO EXTERNAL RESOURCE.
+SERVICE email_mcp SHALL IMPLEMENT INTERFACE mcp_stdio AS MODULE browser_mcp IMPLEMENTS INTERFACE mcp_stdio.
+</trl>
+
+**Decision:** GO. Python imaplib/smtplib are stdlib — zero external dependencies. IMAP is universal (Google Workspace, Proton Bridge, any provider). MCP stdio transport matches existing browser_mcp.py and gimp_mcp.py pattern.
+
+### Risks
+
+<trl>
+IF DATA credential ROUTE TO FILE repository THEN THROW EXCEPTION security_violation.
+AGENT SHALL READ DATA credential FROM ENDPOINT environment_variable.
+FILE email_accounts.json SHALL REQUIRE PRIVATE ACCESS.
+</trl>
+
+<trl>
+IF AGENT DELETE ALL MESSAGE WITHOUT VALID RECORD confirm THEN THROW EXCEPTION data_loss.
+FUNCTION email_delete SHALL REQUIRE ACTIVE RECORD confirm 'before DELETE MESSAGE.
+FUNCTION email_delete SHALL DEFAULT TO RECORD dry_run.
+</trl>
+
+## Phase 3: SPECIFICATIONS
+
+### Tools
+
+<trl>
+DEFINE "read_tools" AS STAGE CONTAINS FUNCTION email_accounts AND FUNCTION email_folders AND FUNCTION email_list AND FUNCTION email_read.
+DEFINE "search_tools" AS STAGE CONTAINS FUNCTION email_search.
+DEFINE "write_tools" AS STAGE CONTAINS FUNCTION email_send AND FUNCTION email_reply AND FUNCTION email_draft.
+DEFINE "organize_tools" AS STAGE CONTAINS FUNCTION email_move AND FUNCTION email_delete AND FUNCTION email_flag.
+SERVICE email_mcp CONTAINS STAGE read_tools AND STAGE search_tools AND STAGE write_tools AND STAGE organize_tools.
+</trl>
+
+### Tool Specifications
+
+<trl>
+FUNCTION email_accounts SHALL READ ALL ENDPOINT imap_account FROM FILE accounts.json THEN WRITE RESULT TO PARTY caller.
+FUNCTION email_folders SHALL READ ALL MODULE folder FROM ENDPOINT imap_account THEN WRITE RESULT TO PARTY caller.
+FUNCTION email_list SHALL FILTER ALL MESSAGE BY MODULE folder AND OPTIONAL ACTIVE state THEN SORT RESULT BY DATA date THEN WRITE RESULT TO PARTY caller.
+FUNCTION email_read SHALL READ A MESSAGE BY DATA uid FROM MODULE folder THEN WRITE RESULT TO PARTY caller.
+FUNCTION email_search SHALL FILTER ALL MESSAGE BY DATA from_addr OR DATA subject OR DATA date OR DATA body THEN WRITE RESULT TO PARTY caller.
+FUNCTION email_send SHALL WRITE MESSAGE TO ENDPOINT smtp THEN SEND MESSAGE TO PARTY recipient.
+FUNCTION email_reply SHALL READ MESSAGE BY DATA uid THEN WRITE MESSAGE TO ENDPOINT smtp THEN SEND MESSAGE TO PARTY original_sender.
+FUNCTION email_draft SHALL WRITE MESSAGE TO MODULE drafts_folder.
+FUNCTION email_move SHALL READ MESSAGE BY DATA uid FROM MODULE source_folder THEN WRITE MESSAGE TO MODULE target_folder THEN DELETE MESSAGE FROM MODULE source_folder.
+FUNCTION email_delete SHALL VALIDATE ACTIVE RECORD confirm THEN DELETE MESSAGE OR WRITE RECORD dry_run TO PARTY caller.
+FUNCTION email_flag SHALL WRITE DATA flag TO MESSAGE BY DATA uid.
+</trl>
+
+### Configuration
+
+<trl>
+FILE email_accounts.json SHALL PERSIST 'at ENDPOINT ~/.config/trugs/.
+FILE email_accounts.json SHALL REQUIRE PRIVATE ACCESS.
+EACH ENDPOINT imap_account SHALL CONTAIN DATA email AND DATA imap_host AND DATA imap_port AND DATA smtp_host AND DATA smtp_port AND DATA password_env.
+NO FILE SHALL CONTAIN DATA password DIRECTLY.
+EACH DATA password SHALL READ FROM ENDPOINT environment_variable.
+</trl>
+
+### Audit Criteria (Phase 8 checks against these)
+
+<trl>
+FUNCTION email_list SHALL RETURN VALID RESULT 'for EACH ENDPOINT imap_account.
+FUNCTION email_read SHALL RETURN DATA body_text AND DATA headers 'for ANY MESSAGE.
+FUNCTION email_send SHALL SEND MESSAGE THEN RETURN DATA message_id.
+FUNCTION email_search SHALL FILTER BY DATA from_addr AND DATA subject AND DATA date.
+FUNCTION email_delete 'with NO RECORD confirm SHALL RETURN RECORD dry_run.
+FUNCTION email_delete 'with ACTIVE RECORD confirm SHALL DELETE MESSAGE.
+NO FUNCTION SHALL WRITE DATA credential TO STREAM log OR FILE.
+ALL FUNCTION SHALL RETURN VALID DATA json.
+SERVICE email_mcp SHALL REQUIRE NO EXTERNAL RESOURCE EXCEPT MODULE python_stdlib.
+</trl>
+
+## Phase 4: ARCHITECTURE
+
+### Decisions
+
+<trl>
+SERVICE email_mcp SHALL USE MODULE imaplib DIRECTLY.
+SERVICE email_mcp SHALL_NOT USE SERVICE thunderbird_api.
+SERVICE email_mcp SHALL PERSIST AS FILE email_mcp.py 'at ENDPOINT TRUGS_WEB/trugs_web/.
+</trl>
+
+**ADR-1261-01:** Direct IMAP/SMTP over Thunderbird WebExtension API. Zero dependencies, works without Thunderbird running, universal across providers.
+
+<trl>
+FILE email_accounts.json SHALL PERSIST 'at ENDPOINT ~/.config/trugs/.
+FILE email_accounts.json SHALL_NOT PERSIST 'at ENDPOINT repository.
+FILE .env SHALL CONTAIN ALL DATA password_env.
+FILE .env SHALL REQUIRE PRIVATE ACCESS.
+</trl>
+
+**ADR-1261-02:** Config in ~/.config/trugs/, not in repo. Credentials via environment variables. Never in the JSON file.
+
+<trl>
+FUNCTION email_delete SHALL DEFAULT TO RECORD dry_run.
+FUNCTION email_delete SHALL REQUIRE EXPLICIT ACTIVE RECORD confirm TO DELETE.
+FUNCTION email_move SHALL REQUIRE DATA target_folder.
+</trl>
+
+**ADR-1261-03:** Destructive operations require explicit confirmation. Default is dry-run.
+
+### Coding Plan
+
+<trl>
+AGENT SHALL CREATE FILE email_mcp.py 'at ENDPOINT TRUGS_WEB/trugs_web/.
+AGENT SHALL IMPLEMENT STAGE read_tools THEN STAGE write_tools THEN STAGE search_tools THEN STAGE organize_tools.
+AGENT SHALL IMPLEMENT FUNCTION config_loader THEN FUNCTION imap_connect THEN FUNCTION smtp_connect.
+AGENT SHALL IMPLEMENT FUNCTION mcp_wrapper FINALLY.
+AGENT SHALL WRITE RECORD test 'for EACH FUNCTION.
+</trl>
+
+## Phase 5: VALIDATION
+
+**HITM Gate — Human approves before coding.**
+
+- [x] Vision → specs → architecture consistent
+- [x] Enough detail to code (12 tools specified)
+- [x] Technology verified (imaplib/smtplib stdlib)
+- [x] Risks mitigated (credentials via env vars, dry-run deletes)
+- [x] Audit criteria defined in Phase 3
+- [x] Coding plan defined in Phase 4
+
+**APPROVED — proceed to execution.**
+
+---
+
+## Phase 6: CODING
+
+Status: COMPLETE
+
+<trl>
+AGENT SHALL IMPLEMENT SERVICE email_mcp SUBJECT_TO RECORD coding_plan.
+</trl>
+
+12 tools implemented in `TRUGS_WEB/trugs_web/email_mcp.py`. Three accounts tested (admin@trugs.ai, xepayacllc@gmail.com, xepayac@gmail.com).
+
+## Phase 7: TESTING
+
+Status: COMPLETE
+
+<trl>
+AGENT SHALL VALIDATE SERVICE email_mcp SUBJECT_TO RECORD audit_criteria.
+</trl>
+
+- email_accounts: returns all configured accounts
+- email_list: returns messages from all 3 accounts
+- email_read: returns full message body and headers
+- email_search: filters by sender, subject, date
+- email_send: sent endorsement emails to 3 professors
+- email_delete: dry-run confirmed, then executed (5,063 archived)
+- email_folders: fixed IMAP LIST parsing, returns folder names + counts
+
+## Phase 8: AUDIT
+
+Status: IN PROGRESS
+
+Checking against Phase 3 audit criteria:
+
+- [x] email_list returns valid results for each account
+- [x] email_read returns body_text and headers
+- [x] email_send sends and returns message_id
+- [x] email_search filters by from, subject, date
+- [x] email_delete without confirm returns dry_run
+- [x] email_delete with confirm deletes
+- [x] No credentials in logs or files
+- [x] All functions return valid JSON
+- [x] Zero external dependencies
+
+## Phase 9: DEPLOYMENT
+
+Status: PR #1263 created. Human merges.

--- a/installers/npm/templates/AAA/README.md
+++ b/installers/npm/templates/AAA/README.md
@@ -1,0 +1,34 @@
+# AAA — 9-Phase Development Protocol
+
+AAA is a development workflow that forces your LLM to plan before it codes, define "done" before it builds, and never ship without your approval.
+
+## When to Use
+
+Any time your LLM needs to build something non-trivial. If the task has unknowns, needs design decisions, or touches multiple files — use AAA.
+
+For simple, known tasks (fix a typo, rename a variable), skip AAA entirely and use a CHORE: branch, do it, PR, merge.
+
+## How It Works
+
+**Two cycles, three human touchpoints:**
+
+```
+PLANNING: VISION → FEASIBILITY → SPECIFICATIONS → ARCHITECTURE → VALIDATION (human approves)
+EXECUTION: CODING → TESTING → AUDIT → DEPLOYMENT (human merges)
+```
+
+1. **You** state what you want (VISION)
+2. **Agent** plans it (phases 2-4), including audit criteria in phase 3
+3. **You** approve the plan (VALIDATION)
+4. **Agent** builds and tests it (phases 6-8), auditing against phase 3 criteria
+5. **You** merge the PR (DEPLOYMENT)
+
+The agent never codes without an approved plan. Never ships without your review.
+
+## Key Rule
+
+Phase 3 (SPECIFICATIONS) defines the audit criteria. Phase 8 (AUDIT) checks against them. The plan defines what "done" looks like before any code is written.
+
+## Example
+
+See [EXAMPLE_email_mcp.md](EXAMPLE_email_mcp.md) — a real AAA plan from building an email MCP server. All 9 phases, TRL specs, audit criteria, and coding plan.

--- a/installers/npm/templates/AGENT.md
+++ b/installers/npm/templates/AGENT.md
@@ -1,0 +1,309 @@
+# TRUGS Agent System
+
+<trl>
+DEFINE "TRUGS" AS NAMESPACE.
+DEFINE "TRL" AS INTERFACE.
+NAMESPACE TRUGS GOVERNS ALL DATA graph AND ALL RECORD sentence.
+INTERFACE TRL GOVERNS ALL RECORD sentence.
+AGENT SHALL READ THIS FILE THEN IMPLEMENT ALL RECORD instruction.
+</trl>
+
+You are an agent that speaks TRL. This file teaches the language. Component folders teach the methodology.
+
+| Component | What it teaches | File |
+|-----------|----------------|------|
+| **Folder** | Machine-readable filesystem index | `FOLDER/AGENT.md` |
+| **AAA** | 9-phase development protocol | `AAA/AGENT.md` |
+| **EPIC** | Portfolio tracking as a graph | `EPIC/AGENT.md` |
+| **Memory** | Persistent context across sessions | `MEMORY/AGENT.md` |
+| **Trugging** | Describing a codebase with TRUGs and TRL | `TRUGGING/AGENT.md` |
+| **Web Hub** | Curated web resource landscape | `WEB_HUB/AGENT.md` |
+| **Skills** | Composable agent actions — primitives and compounds | `SKILLS/AGENT.md` |
+
+Read this file first. Read component files when you need that component.
+
+---
+
+## TRL vs TRUGS — When to Use Which
+
+<trl>
+DEFINE "TRL" AS INTERFACE 'for RECORD sentence.
+DEFINE "TRUGS" AS INTERFACE 'for DATA graph.
+EACH RECORD sentence SHALL COMPILE TO DATA graph.
+EACH DATA graph SHALL COMPILE TO RECORD sentence.
+</trl>
+
+**TRL (sentences)** — use when communicating. Instructions, specifications, acceptance criteria, code comments. Human writes it, agent reads it, both understand it.
+
+**TRUGS (graphs)** — use when storing and executing. Project tracking, validation, traversal, state management. Machines read it, tools validate it, agents navigate it.
+
+| Situation | Use | Why |
+|-----------|-----|-----|
+| Writing instructions | TRL | Human-readable, agent-executable |
+| Code comments | TRL | Compilable documentation |
+| Acceptance criteria | TRL | Both human and agent verify against it |
+| Project tracking | TRUGS | Machines traverse and validate |
+| Development phases | TRL | Communication between human and agent |
+| Execution state | TRUGS | Agent tracks progress as graph nodes |
+| Memory files | English + TRL | Context for future sessions |
+| Validation rules | TRUGS | Tools enforce mechanically |
+
+The sentence is the graph. The graph is the sentence. TRL is how you talk about it. TRUGS is how you store it.
+
+### Side-by-Side Example
+
+**TRL (the sentence):**
+
+```
+<trl>
+SERVICE api SHALL AUTHENTICATE PARTY user
+  THEN READ DATA FROM STREAM database
+  THEN WRITE RESULT TO PARTY user
+  OR THROW EXCEPTION.
+IF SERVICE api THROW EXCEPTION
+  THEN SERVICE api SHALL SEND ERROR TO PARTY user.
+</trl>
+```
+
+**TRUGS (the graph):**
+
+```json
+{
+  "nodes": [
+    {"id": "api", "type": "SERVICE", "properties": {"name": "api"}, "parent_id": null, "contains": [], "metric_level": "BASE_SERVICE", "dimension": "system"},
+    {"id": "user", "type": "PARTY", "properties": {"name": "user"}, "parent_id": null, "contains": [], "metric_level": "BASE_PARTY", "dimension": "system"},
+    {"id": "database", "type": "STREAM", "properties": {"name": "database"}, "parent_id": null, "contains": [], "metric_level": "BASE_STREAM", "dimension": "system"},
+    {"id": "op_auth", "type": "FUNCTION", "properties": {"operation": "AUTHENTICATE", "modal": "SHALL"}, "parent_id": "api", "contains": [], "metric_level": "CENTI_FUNCTION", "dimension": "system"},
+    {"id": "op_read", "type": "FUNCTION", "properties": {"operation": "READ"}, "parent_id": "api", "contains": [], "metric_level": "CENTI_FUNCTION", "dimension": "system"},
+    {"id": "op_write", "type": "FUNCTION", "properties": {"operation": "WRITE"}, "parent_id": "api", "contains": [], "metric_level": "CENTI_FUNCTION", "dimension": "system"},
+    {"id": "op_throw", "type": "EXCEPTION", "properties": {"operation": "THROW"}, "parent_id": "api", "contains": [], "metric_level": "CENTI_EXCEPTION", "dimension": "system"},
+    {"id": "op_send_error", "type": "FUNCTION", "properties": {"operation": "SEND", "object": "ERROR"}, "parent_id": "api", "contains": [], "metric_level": "CENTI_FUNCTION", "dimension": "system"}
+  ],
+  "edges": [
+    {"from_id": "op_auth", "to_id": "user", "relation": "AUTHENTICATE"},
+    {"from_id": "op_auth", "to_id": "op_read", "relation": "THEN"},
+    {"from_id": "op_read", "to_id": "database", "relation": "FROM"},
+    {"from_id": "op_read", "to_id": "op_write", "relation": "THEN"},
+    {"from_id": "op_write", "to_id": "user", "relation": "TO"},
+    {"from_id": "op_write", "to_id": "op_throw", "relation": "OR"},
+    {"from_id": "op_throw", "to_id": "op_send_error", "relation": "THEN"},
+    {"from_id": "op_send_error", "to_id": "user", "relation": "TO"}
+  ]
+}
+```
+
+Same specification. Same structure. Different views.
+
+---
+
+## TRL — The Language
+
+<trl>
+DEFINE "TRL" AS INTERFACE.
+INTERFACE TRL CONTAINS 190 UNIQUE RECORD word.
+EACH RECORD word BELONGS_TO EXACTLY A RECORD part_of_speech.
+EACH RECORD sentence SHALL COMPILE TO DATA graph.
+EACH DATA graph SHALL COMPILE TO RECORD sentence.
+</trl>
+
+### Vocabulary (190 words)
+
+**Nouns — things that exist (become graph nodes)**
+
+<trl>
+DEFINE "actor" AS PARTY OR AGENT OR PROCESS OR SERVICE OR FUNCTION OR TRANSFORM OR PRINCIPAL.
+DEFINE "artifact" AS DATA OR FILE OR RECORD OR MESSAGE OR STREAM OR RESOURCE.
+DEFINE "container" AS PIPELINE OR STAGE OR MODULE OR NAMESPACE.
+DEFINE "boundary" AS ENTRY OR EXIT OR INTERFACE OR ENDPOINT.
+DEFINE "outcome" AS ERROR OR EXCEPTION OR REMEDY.
+</trl>
+
+**Verbs — actions (become operation nodes)**
+
+<trl>
+DEFINE "transform" AS FILTER OR MAP OR SORT OR MERGE OR SPLIT OR AGGREGATE OR GROUP OR DISTINCT OR TAKE OR SKIP.
+DEFINE "move" AS READ OR WRITE OR SEND OR RECEIVE OR REQUEST OR RESPOND OR AUTHENTICATE.
+DEFINE "obligate" AS VALIDATE OR ASSERT OR REQUIRE.
+DEFINE "permit" AS ALLOW OR APPROVE OR GRANT OR OVERRIDE.
+DEFINE "prohibit" AS DENY OR REJECT OR REVOKE.
+DEFINE "control" AS BRANCH OR MATCH OR RETRY OR TIMEOUT OR THROW OR EXISTS OR EXPIRE OR EQUALS OR EXCEEDS.
+DEFINE "bind" AS DEFINE OR DECLARE OR IMPLEMENT OR NEST OR AUGMENT OR REPLACE OR CITE OR ADMINISTER.
+DEFINE "resolve" AS CATCH OR HANDLE OR RECOVER.
+</trl>
+
+**Modals — obligation (modify verbs)**
+
+<trl>
+DEFINE "SHALL" AS REQUIRED RECORD obligation.
+DEFINE "MAY" AS OPTIONAL RECORD permission.
+DEFINE "SHALL_NOT" AS REQUIRED RECORD prohibition.
+EACH RECORD obligation SHALL REQUIRE PARTY AS RECORD subject.
+NO DATA SHALL RECEIVE RECORD obligation.
+NO RECORD SHALL RECEIVE RECORD obligation UNLESS RECORD 'is PARTY.
+</trl>
+
+- SHALL = MUST do this. Failure is a violation.
+- MAY = ALLOWED but not required.
+- SHALL_NOT = MUST NOT do this. Doing it is a violation.
+
+**Adjectives — modify nouns (become node properties)**
+
+<trl>
+DEFINE "type" AS STRING OR INTEGER OR BOOLEAN OR ARRAY OR OBJECT.
+DEFINE "access" AS PUBLIC OR PRIVATE OR CONFIDENTIAL OR READONLY.
+DEFINE "state" AS VALID OR INVALID OR ACTIVE OR PENDING OR FAILED OR MUTABLE OR IMMUTABLE.
+DEFINE "quantity" AS REQUIRED OR OPTIONAL OR UNIQUE OR MULTIPLE.
+DEFINE "priority" AS CRITICAL OR HIGH OR LOW OR DEFAULT.
+</trl>
+
+**Adverbs — modify verbs (become operation properties)**
+
+<trl>
+DEFINE "timing" AS ASYNC OR SYNC OR PARALLEL OR SEQUENTIAL OR IMMEDIATE OR WITHIN.
+DEFINE "repetition" AS ONCE OR ALWAYS OR NEVER OR BOUNDED.
+DEFINE "degree" AS STRICTLY OR SUBSTANTIALLY OR REASONABLY.
+</trl>
+
+**Prepositions — relationships (become graph edges)**
+
+<trl>
+DEFINE "flow" AS FEEDS OR ROUTES OR TO OR FROM OR RETURNS_TO.
+DEFINE "dependency" AS BINDS OR DEPENDS_ON OR IMPLEMENTS OR EXTENDS OR SUBJECT_TO.
+DEFINE "authority" AS GOVERNS OR PURSUANT_TO OR ON_BEHALF_OF.
+DEFINE "structure" AS CONTAINS OR REFERENCES OR SUPERSEDES.
+DEFINE "binding" AS AS OR BY.
+</trl>
+
+**Conjunctions — connect clauses (become structural edges)**
+
+<trl>
+DEFINE "sequence" AS THEN OR FINALLY.
+DEFINE "parallel" AS AND.
+DEFINE "alternative" AS OR OR ELSE.
+DEFINE "conditional" AS IF OR WHEN OR WHILE.
+DEFINE "exception" AS UNLESS OR EXCEPT OR NOTWITHSTANDING OR PROVIDED_THAT OR WHEREAS.
+</trl>
+
+**Articles** — ALL, EACH, EVERY, ANY, SOME, A, THE, THIS, NO, NONE
+
+**Pronouns** — SELF, RESULT, OUTPUT, INPUT, SOURCE, TARGET
+
+**Sugar** — OF, IS, ARE, BE, BEEN, HAS, HAVE, WILL, THAT, WHICH, WHERE, WHO, INTO, UPON, WITH, FOR, AT, ON, PLEASE, ALSO, THEN_ALSO, THESE, THOSE, SUCH (compile to nothing — human readability only)
+
+### How to Read and Execute
+
+<trl>
+AGENT SHALL STRIP ALL RECORD sugar FROM RECORD sentence.
+AGENT SHALL PARSE RECORD sentence AS RECORD subject THEN RECORD modal THEN RECORD verb THEN RECORD object.
+IF RECORD modal EQUALS "SHALL" THEN AGENT SHALL EXECUTE RECORD verb STRICTLY.
+IF RECORD modal EQUALS "MAY" THEN AGENT MAY EXECUTE RECORD verb.
+IF RECORD modal EQUALS "SHALL_NOT" THEN AGENT SHALL_NOT EXECUTE RECORD verb.
+AGENT SHALL FOLLOW RECORD conjunction AS RECORD sequence.
+</trl>
+
+Parse example:
+```
+PARTY system SHALL FILTER ALL ACTIVE RECORD THEN WRITE RESULT TO ENDPOINT output.
+```
+- PARTY system → Actor node (subject)
+- SHALL → obligation
+- FILTER → Transform operation
+- ALL ACTIVE RECORD → scoped, qualified artifact
+- THEN → sequential conjunction
+- WRITE RESULT TO ENDPOINT output → Move operation with destination
+
+### Key Rules
+
+<trl>
+EACH RECORD word SHALL BELONG_TO EXACTLY A RECORD part_of_speech.
+EACH RECORD modal SHALL REQUIRE PARTY AS RECORD subject.
+EACH RECORD pronoun SHALL RESOLVE WITHIN THIS RECORD sentence.
+NO RECORD sentence SHALL CONTAIN "NO" AND "SHALL_NOT" 'in SAME RECORD clause.
+AGENT SHALL STRIP RECORD sugar 'before PARSE RECORD sentence.
+</trl>
+
+---
+
+## Using TRL in Your Project
+
+<trl>
+PARTY human MAY WRITE RECORD trl_block 'in FILE code_comment OR FILE specification OR FILE issue OR FILE config.
+AGENT SHALL READ RECORD trl_block THEN COMPILE TO DATA graph THEN EXECUTE.
+</trl>
+
+### In code comments
+
+```python
+# <trl>FUNCTION validate SHALL VALIDATE ALL REQUIRED RECORD
+#   SUBJECT_TO INTERFACE schema.
+# IF FUNCTION validate THROW EXCEPTION
+#   THEN SEND ERROR TO PARTY caller.</trl>
+def validate(records, schema):
+    for record in records:
+        if not schema.validate(record):
+            raise ValidationError(record.id)
+```
+
+### In specifications
+
+```markdown
+<trl>
+SERVICE api SHALL RESPOND WITHIN 200ms.
+SERVICE api SHALL AUTHENTICATE ALL PARTY 'before READ DATA.
+NO SERVICE api SHALL WRITE INVALID RECORD TO STREAM database.
+SERVICE api SHALL RETRY BOUNDED 3 WITHIN 30s OR THROW EXCEPTION.
+</trl>
+```
+
+### In issue descriptions
+
+```markdown
+<trl>
+AGENT SHALL CREATE MODULE email_mcp CONTAINS FUNCTION send AND FUNCTION read AND FUNCTION search.
+EACH FUNCTION SHALL READ CONFIG FROM FILE accounts.json.
+FUNCTION delete SHALL REQUIRE VALID CONFIRM 'before DELETE RECORD.
+NO FUNCTION SHALL WRITE RECORD password TO FILE OR STREAM.
+</trl>
+```
+
+---
+
+## The Validator
+
+TRUGS graphs are validated by `trugs-validate` — 16 rules that every graph must pass:
+
+- **Rules 1-9 (structural)** — always enforced. Unique IDs, valid edge references, hierarchy consistency, required fields, correct types.
+- **Rules 10-16 (compositional)** — enforced when graph declares `core_v1.0.0`. Subject-operation compatibility, modifier-entity compatibility, no double negation, reference scope.
+
+```bash
+python tools/validate.py my_graph.trug.json       # Validate one
+python tools/validate.py --all my_project/         # Validate all
+```
+
+<trl>
+AGENT SHALL VALIDATE ALL DATA graph SUBJECT_TO INTERFACE core_v1.0.0.
+IF DATA graph 'is INVALID THEN AGENT SHALL FIX DATA graph THEN VALIDATE DATA graph.
+NO AGENT SHALL DEPLOY INVALID DATA graph.
+</trl>
+
+---
+
+## Quick Reference
+
+<trl>
+INTERFACE TRL CONTAINS 190 UNIQUE RECORD word.
+EACH RECORD word SHALL 'have EXACTLY A RECORD meaning.
+NO AGENT SHALL COMMIT TO BRANCH main.
+NO AGENT SHALL MERGE RECORD pull_request.
+</trl>
+
+For component-specific instructions, read the AGENT.md in each folder:
+- **FOLDER/AGENT.md** — filesystem indexing
+- **AAA/AGENT.md** — development protocol
+- **EPIC/AGENT.md** — portfolio tracking
+- **MEMORY/AGENT.md** — persistent context
+- **TRUGGING/AGENT.md** — codebase description
+- **WEB_HUB/AGENT.md** — curated web resource landscape
+- **SKILLS/AGENT.md** — composable agent actions (19 primitives, compound composition)
+
+For the full TRL specification: https://github.com/TRUGS-LLC/TRUGS

--- a/installers/npm/templates/EPIC/AGENT.md
+++ b/installers/npm/templates/EPIC/AGENT.md
@@ -1,0 +1,139 @@
+# EPIC — Agent Instructions
+
+<trl>
+DEFINE "EPIC" AS DATA graph 'for RECORD project_tracking.
+DATA graph EPIC CONTAINS DATA node 'of TYPE TRACKER AND TYPE EPIC AND TYPE TASK.
+DATA graph EPIC CONTAINS DATA edge 'of RELATION BLOCKS AND RELATION DEPENDS_ON AND RELATION IMPLEMENTS.
+AGENT SHALL READ DATA graph EPIC 'at ENTRY RECORD session.
+AGENT SHALL UPDATE DATA graph EPIC WHEN RECORD status CHANGES.
+</trl>
+
+An EPIC is a TRUG graph that tracks your portfolio — projects, tasks, dependencies, and status. You read it to know what exists, what's in progress, what's blocked, and what to work on next.
+
+---
+
+## Structure
+
+<trl>
+DEFINE "TRACKER" AS DATA node 'at KILO METRIC_LEVEL.
+DEFINE "EPIC" AS DATA node 'at HECTO METRIC_LEVEL.
+DEFINE "TASK" AS DATA node 'at BASE METRIC_LEVEL.
+TRACKER CONTAINS EPIC.
+EPIC CONTAINS TASK.
+EACH TASK SHALL CONTAIN RECORD status AND RECORD priority.
+</trl>
+
+Three levels:
+
+```
+TRACKER (root — the whole portfolio)
+  └── EPIC (initiative — a body of related work)
+       └── TASK (work item — one thing to do)
+```
+
+### TRACKER Node
+
+<trl>
+EACH DATA graph EPIC SHALL CONTAIN EXACTLY A DATA node 'of TYPE TRACKER.
+TRACKER SHALL CONTAIN RECORD name AND RECORD owner AND RECORD total_open_issues AND RECORD last_updated.
+TRACKER SHALL CONTAIN RECORD present_plan 'with RECORD summary AND RECORD active_issues.
+</trl>
+
+The root node. One per project. Contains the current focus and open issue count. This is the first thing you read.
+
+### EPIC Node
+
+<trl>
+EACH EPIC SHALL CONTAIN RECORD name AND RECORD purpose AND RECORD status.
+RECORD status SHALL 'be "TODO" OR "IN_PROGRESS" OR "DONE" OR "BLOCKED".
+EPIC MAY CONTAIN RECORD github_issue AND RECORD labels AND RECORD created_date.
+EACH EPIC SHALL CONTAIN ONE OR MORE TASK.
+</trl>
+
+An initiative — a group of related tasks toward a goal. Has a purpose (why it exists) and a status.
+
+### TASK Node
+
+<trl>
+EACH TASK SHALL CONTAIN RECORD name AND RECORD status AND RECORD priority.
+RECORD priority SHALL 'be "P0" OR "P1" OR "P2" OR "P3".
+TASK MAY CONTAIN RECORD github_issue AND RECORD assignee.
+</trl>
+
+A single work item. Has a priority and a status. Maps to a GitHub issue when one exists.
+
+---
+
+## Edges
+
+<trl>
+DEFINE "BLOCKS" AS DATA edge — TARGET SHALL_NOT START UNTIL SOURCE 'is DONE.
+DEFINE "DEPENDS_ON" AS DATA edge — TARGET REQUIRES SOURCE TO FUNCTION.
+DEFINE "IMPLEMENTS" AS DATA edge — TARGET DELIVERS SOURCE.
+EACH DATA edge SHALL CONTAIN RECORD from_id AND RECORD to_id AND RECORD relation.
+DATA edge MAY CONTAIN RECORD description.
+</trl>
+
+| Relation | Meaning | Example |
+|----------|---------|---------|
+| `BLOCKS` | Can't start B until A is done | "Deploy" BLOCKS "Test in production" |
+| `DEPENDS_ON` | B requires A to function | "API" DEPENDS_ON "Auth module" |
+| `IMPLEMENTS` | B delivers A | Task IMPLEMENTS Epic |
+
+---
+
+## Reading the EPIC
+
+<trl>
+AGENT SHALL READ DATA graph EPIC 'at ENTRY RECORD session.
+AGENT SHALL IDENTIFY ALL TASK 'where RECORD status EQUALS "IN_PROGRESS".
+AGENT SHALL IDENTIFY ALL TASK 'where RECORD status EQUALS "BLOCKED".
+AGENT SHALL IDENTIFY ALL DATA edge 'of RELATION BLOCKS TO UNDERSTAND RECORD dependency.
+AGENT SHALL READ RECORD present_plan FROM TRACKER TO UNDERSTAND RECORD current_focus.
+</trl>
+
+At session start, read the EPIC to answer:
+1. **What's the current focus?** → `tracker.present_plan.summary`
+2. **What's in progress?** → all tasks with status `IN_PROGRESS`
+3. **What's blocked and by what?** → follow `BLOCKS` edges
+4. **What should I work on next?** → highest priority `TODO` task that isn't blocked
+
+---
+
+## Updating the EPIC
+
+<trl>
+IF AGENT START TASK THEN AGENT SHALL SET RECORD status TO "IN_PROGRESS".
+IF AGENT COMPLETE TASK THEN AGENT SHALL SET RECORD status TO "DONE".
+IF TASK 'is BLOCKED THEN AGENT SHALL SET RECORD status TO "BLOCKED" AND CREATE DATA edge 'of RELATION BLOCKS.
+IF AGENT CREATE RECORD issue THEN AGENT SHALL CREATE TASK 'in EPIC 'with RECORD github_issue.
+AGENT SHALL UPDATE RECORD last_updated 'on TRACKER AFTER EACH CHANGE.
+AGENT SHALL UPDATE RECORD total_open_issues 'on TRACKER AFTER EACH CHANGE.
+</trl>
+
+Keep the EPIC in sync with reality:
+- Start a task → mark IN_PROGRESS
+- Finish a task → mark DONE
+- Hit a blocker → mark BLOCKED + add BLOCKS edge
+- Create a GitHub issue → add a TASK node with the issue number
+- Any change → update `last_updated` and `total_open_issues` on the tracker
+
+---
+
+## Creating an EPIC from Scratch
+
+<trl>
+AGENT SHALL SCAN NAMESPACE project 'for ALL RECORD initiative.
+'for EACH RECORD initiative AGENT SHALL CREATE DATA node 'of TYPE EPIC.
+'for EACH RECORD work_item AGENT SHALL CREATE DATA node 'of TYPE TASK.
+AGENT SHALL CREATE DATA edge 'for EACH RECORD dependency 'between TASK.
+AGENT SHALL VALIDATE DATA graph EPIC.
+</trl>
+
+1. Identify the major initiatives (epics)
+2. Break each into tasks
+3. Map dependencies as BLOCKS/DEPENDS_ON edges
+4. Set priorities and statuses
+5. Validate the graph
+
+See [EXAMPLE_project.trug.json](EXAMPLE_project.trug.json) for a starter template.

--- a/installers/npm/templates/EPIC/EXAMPLE_project.trug.json
+++ b/installers/npm/templates/EPIC/EXAMPLE_project.trug.json
@@ -1,0 +1,89 @@
+{
+  "name": "Project Tracker",
+  "version": "1.0.0",
+  "type": "TRACKER",
+  "description": "Portfolio tracker for your project. Tracks epics, tasks, and their relationships.",
+  "dimensions": {
+    "project_tracking": {
+      "description": "Work management: tracker > epics > tasks",
+      "base_level": "BASE"
+    }
+  },
+  "capabilities": {
+    "extensions": [],
+    "vocabularies": ["core_v1.0.0"],
+    "profiles": []
+  },
+  "nodes": [
+    {
+      "id": "tracker_root",
+      "type": "TRACKER",
+      "properties": {
+        "name": "My Project",
+        "owner": "your-name",
+        "total_open_issues": 0,
+        "last_updated": "2026-04-01",
+        "present_plan": {
+          "summary": "Describe your current focus here.",
+          "active_issues": []
+        }
+      },
+      "parent_id": null,
+      "contains": ["epic_example"],
+      "metric_level": "KILO_TRACKER",
+      "dimension": "project_tracking"
+    },
+    {
+      "id": "epic_example",
+      "type": "EPIC",
+      "properties": {
+        "name": "Example Epic — Replace With Your First Initiative",
+        "purpose": "What this epic achieves and why it matters.",
+        "status": "IN_PROGRESS",
+        "github_issue": null,
+        "labels": [],
+        "created_date": "2026-04-01"
+      },
+      "parent_id": "tracker_root",
+      "contains": ["task_example_1", "task_example_2"],
+      "metric_level": "HECTO_EPIC",
+      "dimension": "project_tracking"
+    },
+    {
+      "id": "task_example_1",
+      "type": "TASK",
+      "properties": {
+        "name": "First task — replace with real work",
+        "status": "TODO",
+        "github_issue": null,
+        "priority": "P1"
+      },
+      "parent_id": "epic_example",
+      "contains": [],
+      "metric_level": "BASE_TASK",
+      "dimension": "project_tracking"
+    },
+    {
+      "id": "task_example_2",
+      "type": "TASK",
+      "properties": {
+        "name": "Second task — depends on first",
+        "status": "TODO",
+        "github_issue": null,
+        "priority": "P2"
+      },
+      "parent_id": "epic_example",
+      "contains": [],
+      "metric_level": "BASE_TASK",
+      "dimension": "project_tracking"
+    }
+  ],
+  "edges": [
+    {
+      "from_id": "task_example_2",
+      "to_id": "task_example_1",
+      "relation": "BLOCKS",
+      "properties": {"description": "Task 2 cannot start until task 1 is complete"}
+    }
+  ]
+}

--- a/installers/npm/templates/EPIC/README.md
+++ b/installers/npm/templates/EPIC/README.md
@@ -1,0 +1,33 @@
+# EPIC — Portfolio Tracker
+
+An EPIC is a TRUG graph that tracks your projects, tasks, and their dependencies. Your LLM reads it to know what's in progress, what's blocked, and what to work on next.
+
+## When to Use
+
+When you have more than one initiative happening at once. The EPIC gives your LLM a bird's-eye view of all work — no more re-explaining context every session.
+
+## How It Works
+
+An EPIC is a `.trug.json` file with three levels:
+
+```
+TRACKER (root)
+  └── EPIC (initiative)
+       └── TASK (work item)
+```
+
+Edges express dependencies: `BLOCKS`, `DEPENDS_ON`, `IMPLEMENTS`.
+
+Your LLM reads the EPIC at session start to understand:
+- What projects exist and their status
+- What tasks are TODO, IN_PROGRESS, or DONE
+- What's blocked and by what
+- What the current focus is
+
+## Key Rule
+
+The EPIC is the single source of truth for project state. When your LLM needs to know "what should I work on?", it reads the EPIC — not a chat history, not a TODO list.
+
+## Example
+
+See [EXAMPLE_project.trug.json](EXAMPLE_project.trug.json) — a starter tracker with epics, tasks, and BLOCKS dependency edges. Copy it, replace the placeholder content, and your LLM has a project map.

--- a/installers/npm/templates/FOLDER/AGENT.md
+++ b/installers/npm/templates/FOLDER/AGENT.md
@@ -1,0 +1,311 @@
+# FOLDER — Agent Instructions
+
+<trl>
+DEFINE "folder.trug.json" AS DATA graph 'for MODULE folder.
+EACH MODULE folder SHALL CONTAIN EXACTLY A FILE folder.trug.json.
+FILE folder.trug.json SHALL 'be RECORD ground_truth 'for MODULE folder.
+AGENT SHALL READ FILE folder.trug.json 'at ENTRY MODULE folder.
+AGENT SHALL UPDATE FILE folder.trug.json WHEN AGENT MODIFY MODULE folder.
+</trl>
+
+A `folder.trug.json` is a TRUG graph that indexes a directory. Every file is a node. Every relationship is an edge. You read it to know what exists, what each file does, and how things connect — without opening every file.
+
+---
+
+## The Four-File Pattern
+
+<trl>
+EACH MODULE folder MAY CONTAIN FILE folder.trug.json AND FILE README.md AND FILE ARCHITECTURE.md AND FILE AAA.md.
+FILE folder.trug.json SHALL 'be RECORD ground_truth.
+FILE README.md SHALL 'be RECORD narrative 'for PARTY human.
+FILE ARCHITECTURE.md SHALL 'be RECORD auto_generated FROM FILE folder.trug.json.
+FILE AAA.md SHALL 'be RECORD auto_generated FROM ENDPOINT github_issue.
+NO AGENT SHALL MODIFY FILE ARCHITECTURE.md.
+NO AGENT SHALL MODIFY FILE AAA.md.
+</trl>
+
+| File | Owner | Agent Action |
+|------|-------|-------------|
+| **folder.trug.json** | Human-maintained | Read first. Update when files change. |
+| **README.md** | Human-written | Read for motivation if needed. |
+| **ARCHITECTURE.md** | Auto-generated nightly | Never edit. Read for rendered reference. |
+| **AAA.md** | Auto-generated from GitHub Issues | Never edit. Read for active work spec. |
+
+### How to Enter a Folder
+
+<trl>
+AGENT SHALL READ FILE folder.trug.json THEN READ FILE AAA.md IF EXISTS THEN READ FILE README.md IF REQUIRED.
+AGENT SHALL SKIP FILE ARCHITECTURE.md — DATA 'is 'in FILE folder.trug.json.
+AGENT SHALL SKIP ALL FILE 'with PREFIX "zzz_" — RECORD archived.
+</trl>
+
+1. Read `folder.trug.json` — know every file, component, and relationship
+2. Read `AAA.md` (if present) — know the current task and phase
+3. Read `README.md` only if you need motivation or context
+4. Skip `ARCHITECTURE.md` — same data as the TRUG, just rendered
+5. Skip `zzz_*` files — archived, irrelevant
+
+---
+
+## Node Types
+
+<trl>
+DEFINE "FOLDER" AS DATA node 'at KILO METRIC_LEVEL — THE FOLDER ITSELF.
+DEFINE "DOCUMENT" AS DATA node 'at BASE METRIC_LEVEL — MARKDOWN FILE.
+DEFINE "SPECIFICATION" AS DATA node 'at BASE METRIC_LEVEL — SPEC OR PROTOCOL FILE.
+DEFINE "COMPONENT" AS DATA node 'at DEKA METRIC_LEVEL — MAJOR CODE SUBSYSTEM.
+DEFINE "TEST_SUITE" AS DATA node 'at BASE METRIC_LEVEL — TEST DIRECTORY OR COLLECTION.
+DEFINE "EXAMPLE_SET" AS DATA node 'at BASE METRIC_LEVEL — EXAMPLES DIRECTORY.
+DEFINE "SCHEMA" AS DATA node 'at BASE METRIC_LEVEL — JSON SCHEMA FILE.
+DEFINE "TEMPLATE" AS DATA node 'at BASE METRIC_LEVEL — GENERATOR TEMPLATE.
+EACH DATA node SHALL CONTAIN RECORD id AND RECORD type AND RECORD properties AND RECORD parent_id AND RECORD contains AND RECORD metric_level AND RECORD dimension.
+</trl>
+
+| Type | What It Represents | metric_level |
+|------|-------------------|-------------|
+| `FOLDER` | The folder itself — exactly one, root node | `KILO_FOLDER` |
+| `DOCUMENT` | Markdown docs (README, guides, references) | `BASE_DOCUMENT` |
+| `SPECIFICATION` | Spec and protocol files — define behavior | `BASE_SPECIFICATION` |
+| `COMPONENT` | A major code subsystem (validator, CLI, engine) | `DEKA_COMPONENT` |
+| `TEST_SUITE` | A test directory or collection | `BASE_TEST_SUITE` |
+| `EXAMPLE_SET` | An examples directory or collection | `BASE_EXAMPLE_SET` |
+| `SCHEMA` | A JSON Schema file | `BASE_SCHEMA` |
+| `TEMPLATE` | A generator template | `BASE_TEMPLATE` |
+
+### Node Properties
+
+<trl>
+EACH DATA node SHALL CONTAIN RECORD name 'in RECORD properties.
+EACH DATA node SHALL CONTAIN RECORD purpose 'in RECORD properties — A RECORD sentence DESCRIBING WHAT FILE DOES.
+DATA node MAY CONTAIN RECORD format AND RECORD status AND RECORD stale AND RECORD verified.
+IF RECORD stale EQUALS TRUE THEN FILE 'is MISSING FROM DISK.
+IF RECORD planned EQUALS TRUE THEN FILE 'will 'be CREATED BY FUTURE RECORD issue.
+IF RECORD verified EQUALS TRUE THEN PARTY human 'has CONFIRMED DATA node 'is ACCURATE.
+</trl>
+
+Every node has a `purpose` field — one sentence explaining what the file does. This is what saves tokens: you read the purpose instead of opening the file.
+
+```json
+{
+  "id": "doc_specification",
+  "type": "SPECIFICATION",
+  "properties": {
+    "name": "SPEC_computation.md",
+    "purpose": "Formal specification for TRUGS Computation — 23-operation vocabulary, type system, and 6 validation rules",
+    "format": "markdown"
+  },
+  "parent_id": "computation_folder",
+  "contains": [],
+  "metric_level": "BASE_SPECIFICATION",
+  "dimension": "folder_structure"
+}
+```
+
+---
+
+## Edge Relations
+
+<trl>
+DEFINE "contains" AS DATA edge — FOLDER DIRECTLY CONTAINS THIS NODE.
+DEFINE "uses" AS DATA edge — RUNTIME OR BUILD DEPENDENCY.
+DEFINE "produces" AS DATA edge — THIS COMPONENT GENERATES 'that OUTPUT.
+DEFINE "validates" AS DATA edge — THIS NODE VALIDATES 'that NODE.
+DEFINE "implements" AS DATA edge — CODE 'that REALIZES A SPEC.
+DEFINE "tests" AS DATA edge — TEST SUITE COVERS THIS COMPONENT.
+DEFINE "describes" AS DATA edge — DOCUMENT EXPLAINS THIS NODE.
+DEFINE "governs" AS DATA edge — OWNS POLICY OR COMPLIANCE RULES.
+EACH DATA edge SHALL CONTAIN RECORD from_id AND RECORD to_id AND RECORD relation AND RECORD properties.
+RECORD properties SHALL 'be OBJECT — MUST 'be PRESENT EVEN WHEN EMPTY.
+</trl>
+
+| Relation | From → To | Meaning |
+|----------|-----------|---------|
+| `contains` | FOLDER → any | Folder directly contains this node |
+| `uses` | any → COMPONENT, SPEC, SCHEMA | Runtime or build-time dependency |
+| `produces` | COMPONENT, TEMPLATE → DOCUMENT, EXAMPLE_SET | This component generates that output |
+| `validates` | SCHEMA, COMPONENT → any | This node validates that node |
+| `implements` | COMPONENT → SPECIFICATION | Code that realizes a spec |
+| `tests` | TEST_SUITE → COMPONENT | Test suite covers this component |
+| `describes` | DOCUMENT → any | Document explains this node |
+| `governs` | FOLDER, SPECIFICATION → any | Owns policy or compliance rules |
+
+### Edge Format
+
+```json
+{
+  "from_id": "validator_component",
+  "to_id": "spec_validation",
+  "relation": "implements",
+  "properties": {}
+}
+```
+
+### Cross-Folder Edges
+
+<trl>
+DATA edge MAY REFERENCE DATA node 'in ANOTHER MODULE folder.
+CROSS-FOLDER RECORD to_id SHALL USE RECORD syntax "folder_name:node_id".
+EACH MODULE folder SHALL DECLARE ONLY ITS OWN OUTBOUND DATA edge.
+NO MODULE folder SHALL DECLARE DATA edge 'for ANOTHER MODULE folder.
+</trl>
+
+When a node depends on something in another folder, use qualified IDs:
+
+```json
+{
+  "from_id": "validator_component",
+  "to_id": "trugs_protocol:spec_validation",
+  "relation": "implements",
+  "properties": {}
+}
+```
+
+The prefix before `:` is the folder name. Each folder declares its own outbound edges. No folder speaks for another.
+
+---
+
+## Building a folder.trug.json
+
+<trl>
+AGENT SHALL BUILD FILE folder.trug.json FROM RECORD filesystem — NOT FROM FILE AAA.md OR FILE README.md.
+AGENT SHALL COUNT FILE 'on DISK USING RECORD command ls OR find OR wc.
+AGENT SHALL READ RECORD source — FILE pyproject.toml AND RECORD test_runner AND RECORD directory_listing.
+AGENT SHALL VERIFY EACH RECORD numeric_property AGAINST RECORD filesystem 'before COMMIT.
+NO AGENT SHALL USE RECORD prose_document AS SOURCE 'for RECORD count OR RECORD file_list.
+</trl>
+
+### The Hard Rule
+
+**The filesystem is the source of truth.** Not AAA.md. Not README.md. Not prose documents. Count files on disk. Read actual source. Verify every number.
+
+| Data Needed | Source | NOT This |
+|-------------|--------|----------|
+| File counts | `ls`, `find`, `wc -l` | AAA.md prose |
+| Component list | Directory listing + imports | AAA.md component section |
+| Test count | Test runner output | AAA.md status line |
+| Schema list | `ls schemas/*.json` | AAA.md table |
+| Phase/status | AAA.md (this IS intent data) | — |
+| Edge relationships | Code inspection + human judgment | — |
+
+### Step by Step
+
+<trl>
+AGENT SHALL LIST ALL FILE 'in MODULE folder.
+'for EACH FILE AGENT SHALL CREATE DATA node 'with RECORD type AND RECORD purpose.
+AGENT SHALL CREATE EXACTLY A DATA node 'of TYPE FOLDER AS RECORD root.
+AGENT SHALL SET RECORD parent_id AND RECORD contains 'for HIERARCHY.
+AGENT SHALL CREATE DATA edge 'for EACH RECORD relationship 'between DATA node.
+AGENT SHALL VALIDATE FILE folder.trug.json.
+</trl>
+
+1. **List files on disk** — `ls`, `find`
+2. **Create the FOLDER node** — one root node, `parent_id: null`
+3. **Create a node for each file/component** — type it correctly, write a one-sentence purpose
+4. **Set hierarchy** — `parent_id` points up, `contains` points down, both must agree
+5. **Create edges** — `implements`, `tests`, `uses`, `describes`, etc.
+6. **Validate** — run `trugs-folder-check` or `python tools/validate.py`
+
+---
+
+## Lifecycle Properties
+
+<trl>
+IF FILE 'is MISSING FROM DISK THEN AGENT SHALL SET RECORD stale TO TRUE 'on DATA node.
+IF FILE 'will 'be CREATED BY FUTURE RECORD issue THEN PARTY human SHALL SET RECORD planned TO TRUE.
+IF PARTY human CONFIRMS DATA node 'is ACCURATE THEN PARTY human SHALL SET RECORD verified TO TRUE.
+IF FILE folder.trug.json CHANGES AFTER RECORD verified 'is SET THEN RECORD verified SHALL 'be CLEARED.
+</trl>
+
+| Property | Set By | Meaning |
+|----------|--------|---------|
+| `stale: true` | Automation | File was here, now gone from disk |
+| `stale_reason` | Automation | Why the node is stale |
+| `planned: true` | Human | File will be created by a future issue |
+| `planned_issue` | Human | GitHub issue that will create the file |
+| `verified: true` | Human | Human confirmed this node is accurate |
+| `verified_by` | Human | Who verified it |
+| `verified_date` | Human | When it was verified |
+
+### Trust Signal
+
+| verified | stale | Interpretation |
+|----------|-------|---------------|
+| true | false | Fully trusted — human confirmed, unchanged since |
+| false | false | Unreviewed — synced but no human sign-off |
+| false | true | Stale — drift detected, downgrade trust |
+| true | true | Conflict — human verified but drift detected since |
+
+---
+
+## Maintaining folder.trug.json
+
+<trl>
+IF AGENT CREATE FILE 'in MODULE folder THEN AGENT SHALL ADD DATA node TO FILE folder.trug.json.
+IF AGENT DELETE FILE 'in MODULE folder THEN AGENT SHALL SET RECORD stale TO TRUE 'on DATA node.
+IF AGENT CREATE RECORD relationship THEN AGENT SHALL ADD DATA edge.
+AGENT SHALL_NOT REMOVE DATA node — SET RECORD stale INSTEAD.
+AGENT SHALL UPDATE RECORD purpose IF FILE RECORD content CHANGES SIGNIFICANTLY.
+</trl>
+
+- **New file** → add a node with type and purpose
+- **Deleted file** → set `stale: true` on the node (never remove nodes)
+- **New relationship** → add an edge
+- **Changed file** → update the purpose if the file's role changed
+- **Renamed file** → update the `name` property, keep the same `id`
+
+---
+
+## Document Naming Convention
+
+<trl>
+EACH FILE CREATED BY PARTY human SHALL FOLLOW RECORD pattern "TYPE_description.md".
+RECORD TYPE SHALL 'be UPPERCASE — TELLS RECORD type WITHOUT READING FILE.
+RECORD description SHALL 'be LOWERCASE 'with UNDERSCORES.
+</trl>
+
+```
+TYPE_description_in_lowercase.md
+```
+
+Valid types: `VISION`, `SPEC`, `PROPOSAL`, `RESEARCH`, `GUIDE`, `PLAN`, `REPORT`, `ANALYSIS`, `REFERENCE`, `PITCH`, `PROMPT`, `AUDIT`, `STANDARD`, `MIGRATION`, `ROADMAP`, `TODO`
+
+An agent seeing `SPEC_computation.md` knows it's a specification about computation — without opening the file. Compare with `notes.md` or `design.md` where you'd have to read it to find out.
+
+---
+
+## The zzz_ Archive Convention
+
+<trl>
+NO AGENT SHALL READ FILE 'with PREFIX "zzz_".
+NO AGENT SHALL REFERENCE FILE 'with PREFIX "zzz_" 'in DATA graph.
+NO AGENT SHALL CREATE DATA node 'for FILE 'with PREFIX "zzz_".
+FILE 'with PREFIX "zzz_" 'is RECORD archived — INVISIBLE TO AGENT.
+</trl>
+
+Files prefixed with `zzz_` are archived — pending human review before deletion. They sort to the bottom of directory listings. They are invisible to agents and to the graph. Never read, reference, or index them.
+
+---
+
+## CLI Tools
+
+<trl>
+AGENT MAY USE RECORD command "trugs-folder-init" TO CREATE FILE folder.trug.json FROM RECORD filesystem.
+AGENT MAY USE RECORD command "trugs-folder-sync" TO UPDATE FILE folder.trug.json FROM RECORD filesystem.
+AGENT SHALL USE RECORD command "trugs-folder-check" TO VALIDATE FILE folder.trug.json.
+AGENT MAY USE RECORD command "trugs-folder-render" TO GENERATE FILE ARCHITECTURE.md FROM FILE folder.trug.json.
+</trl>
+
+```bash
+trugs-folder-init [PATH]              # Generate starter folder.trug.json from directory scan
+trugs-folder-sync [PATH] [--all]      # Add nodes for new files, mark missing files stale
+trugs-folder-check [PATH] [--all]     # Validate folder.trug.json — exit 0 = pass, exit 1 = errors
+trugs-folder-render [PATH] [--all]    # Regenerate ARCHITECTURE.md from folder.trug.json
+```
+
+`trugs-folder-sync` rules:
+- Adds nodes for new files found on disk
+- Sets `stale: true` on nodes whose files are missing
+- Never removes nodes
+- Never modifies human-curated edges
+
+See [EXAMPLE_folder.trug.json](EXAMPLE_folder.trug.json) for a complete example.

--- a/installers/npm/templates/FOLDER/EXAMPLE_folder.trug.json
+++ b/installers/npm/templates/FOLDER/EXAMPLE_folder.trug.json
@@ -1,0 +1,167 @@
+{
+  "name": "Auth Module",
+  "version": "1.0.0",
+  "type": "MODULE",
+  "description": "Authentication and authorization — JWT validation, session management, role-based access control",
+  "dimensions": {
+    "folder_structure": {
+      "description": "Auth module file and component structure",
+      "base_level": "BASE"
+    }
+  },
+  "capabilities": {
+    "extensions": [],
+    "vocabularies": ["project_v1"],
+    "profiles": []
+  },
+  "nodes": [
+    {
+      "id": "auth_folder",
+      "type": "FOLDER",
+      "properties": {
+        "name": "auth",
+        "purpose": "Authentication and authorization module — JWT tokens, sessions, RBAC",
+        "verified": false,
+        "stale": false
+      },
+      "parent_id": null,
+      "contains": ["spec_auth", "component_jwt", "component_sessions", "component_rbac", "doc_readme", "test_suite"],
+      "metric_level": "KILO_FOLDER",
+      "dimension": "folder_structure"
+    },
+    {
+      "id": "spec_auth",
+      "type": "SPECIFICATION",
+      "properties": {
+        "name": "SPEC_auth.md",
+        "purpose": "Formal auth specification — token format, expiration rules, role hierarchy, rate limits",
+        "format": "markdown"
+      },
+      "parent_id": "auth_folder",
+      "contains": [],
+      "metric_level": "BASE_SPECIFICATION",
+      "dimension": "folder_structure"
+    },
+    {
+      "id": "component_jwt",
+      "type": "COMPONENT",
+      "properties": {
+        "name": "jwt_handler.py",
+        "purpose": "JWT token creation, validation, and refresh — HS256, 15min access / 7d refresh",
+        "language": "python"
+      },
+      "parent_id": "auth_folder",
+      "contains": [],
+      "metric_level": "DEKA_COMPONENT",
+      "dimension": "folder_structure"
+    },
+    {
+      "id": "component_sessions",
+      "type": "COMPONENT",
+      "properties": {
+        "name": "sessions.py",
+        "purpose": "Server-side session store — Redis-backed, 24h TTL, sliding expiration",
+        "language": "python"
+      },
+      "parent_id": "auth_folder",
+      "contains": [],
+      "metric_level": "DEKA_COMPONENT",
+      "dimension": "folder_structure"
+    },
+    {
+      "id": "component_rbac",
+      "type": "COMPONENT",
+      "properties": {
+        "name": "rbac.py",
+        "purpose": "Role-based access control — admin/editor/viewer hierarchy, permission checks",
+        "language": "python"
+      },
+      "parent_id": "auth_folder",
+      "contains": [],
+      "metric_level": "DEKA_COMPONENT",
+      "dimension": "folder_structure"
+    },
+    {
+      "id": "doc_readme",
+      "type": "DOCUMENT",
+      "properties": {
+        "name": "README.md",
+        "purpose": "Auth module quickstart — setup, configuration, usage examples",
+        "format": "markdown"
+      },
+      "parent_id": "auth_folder",
+      "contains": [],
+      "metric_level": "BASE_DOCUMENT",
+      "dimension": "folder_structure"
+    },
+    {
+      "id": "test_suite",
+      "type": "TEST_SUITE",
+      "properties": {
+        "name": "tests/",
+        "purpose": "Auth test suite — 43 tests covering JWT, sessions, RBAC, and integration",
+        "test_count": 43
+      },
+      "parent_id": "auth_folder",
+      "contains": [],
+      "metric_level": "BASE_TEST_SUITE",
+      "dimension": "folder_structure"
+    }
+  ],
+  "edges": [
+    {
+      "from_id": "component_jwt",
+      "to_id": "spec_auth",
+      "relation": "implements",
+      "properties": {"scope": "JWT token format and expiration rules"}
+    },
+    {
+      "from_id": "component_sessions",
+      "to_id": "spec_auth",
+      "relation": "implements",
+      "properties": {"scope": "Session TTL and sliding expiration"}
+    },
+    {
+      "from_id": "component_rbac",
+      "to_id": "spec_auth",
+      "relation": "implements",
+      "properties": {"scope": "Role hierarchy and permission model"}
+    },
+    {
+      "from_id": "component_rbac",
+      "to_id": "component_jwt",
+      "relation": "uses",
+      "properties": {"reason": "RBAC reads role claims from JWT payload"}
+    },
+    {
+      "from_id": "test_suite",
+      "to_id": "component_jwt",
+      "relation": "tests",
+      "properties": {}
+    },
+    {
+      "from_id": "test_suite",
+      "to_id": "component_sessions",
+      "relation": "tests",
+      "properties": {}
+    },
+    {
+      "from_id": "test_suite",
+      "to_id": "component_rbac",
+      "relation": "tests",
+      "properties": {}
+    },
+    {
+      "from_id": "doc_readme",
+      "to_id": "auth_folder",
+      "relation": "describes",
+      "properties": {}
+    },
+    {
+      "from_id": "component_sessions",
+      "to_id": "infrastructure:redis",
+      "relation": "uses",
+      "properties": {"reason": "Redis for session storage"}
+    }
+  ]
+}

--- a/installers/npm/templates/FOLDER/README.md
+++ b/installers/npm/templates/FOLDER/README.md
@@ -1,0 +1,74 @@
+# FOLDER — Machine-Readable Filesystem Index
+
+A `folder.trug.json` is a TRUG graph that indexes the contents of a directory — every file, every component, every relationship — so your LLM can navigate a codebase without reading everything in it.
+
+## When to Use
+
+Any project folder that an LLM will work in repeatedly. The cost is one JSON file per folder. The payoff is that your LLM stops wasting tokens reading files just to figure out what they are.
+
+## The Problem It Solves
+
+LLMs read everything in their context window. Every file costs tokens. Every irrelevant file wastes capacity. Every ambiguously named file forces the agent to open it just to decide if it matters.
+
+The solution is not fewer files — it's a machine-readable index. One JSON file tells the agent what exists, what each file does, and how things relate. The agent reads the index, picks what it needs, and skips everything else.
+
+## The Four-File Pattern
+
+Every folder that matters has up to four standard files:
+
+| File | Who Writes It | What It Does |
+|------|--------------|--------------|
+| **folder.trug.json** | Human (maintained) | Machine-readable graph — ground truth of contents and relationships |
+| **README.md** | Human | Prose quickstart — motivation, purpose, getting started |
+| **ARCHITECTURE.md** | Auto-generated | Dense technical reference rendered from folder.trug.json |
+| **AAA.md** | Auto-generated | Active work spec rendered from GitHub Issues |
+
+An agent entering any folder reads `folder.trug.json` first. Two to three files and it has full context.
+
+## How It Works
+
+A `folder.trug.json` is a TRUG graph where:
+- **Nodes** are files, components, specs, test suites, schemas — anything in the folder
+- **Edges** are relationships: `implements`, `tests`, `uses`, `describes`, `governs`
+- **Hierarchy** shows what belongs to what via `parent_id` and `contains`
+
+Each node has a `purpose` field — one sentence explaining what the file does. An agent reads this instead of opening the file.
+
+## Node Types
+
+| Type | Represents |
+|------|-----------|
+| `FOLDER` | The folder itself (exactly one, root node) |
+| `DOCUMENT` | Markdown docs (README, guides, references) |
+| `SPECIFICATION` | Spec and protocol files |
+| `COMPONENT` | A major code subsystem |
+| `TEST_SUITE` | A test directory or collection |
+| `EXAMPLE_SET` | An examples directory or collection |
+| `SCHEMA` | A JSON Schema file |
+| `TEMPLATE` | A generator template |
+
+## Edge Relations
+
+| Relation | Meaning |
+|----------|---------|
+| `contains` | Folder directly contains this node |
+| `uses` | Runtime or build-time dependency |
+| `produces` | This component generates that output |
+| `validates` | This node validates that node |
+| `implements` | Code that realizes a spec |
+| `tests` | Test suite covers this component |
+| `describes` | Document explains this node |
+| `governs` | Owns policy or compliance rules |
+
+## CLI Tools
+
+```bash
+trugs-folder-init [PATH]    # Generate starter folder.trug.json from directory scan
+trugs-folder-sync [PATH]    # Update nodes for new/missing files
+trugs-folder-check [PATH]   # Validate folder.trug.json — exit 0 = pass
+trugs-folder-render [PATH]  # Regenerate ARCHITECTURE.md from folder.trug.json
+```
+
+## Example
+
+See [EXAMPLE_folder.trug.json](EXAMPLE_folder.trug.json) for a real folder.trug.json from a Python module with specs, components, tests, and cross-folder edges.

--- a/installers/npm/templates/MEMORY/AGENT.md
+++ b/installers/npm/templates/MEMORY/AGENT.md
@@ -1,0 +1,179 @@
+# Memory — Agent Instructions
+
+<trl>
+DEFINE "Memory" AS MODULE CONTAINS RECORD user AND RECORD feedback AND RECORD project AND RECORD reference.
+AGENT SHALL READ FILE MEMORY.md 'at ENTRY RECORD session.
+AGENT SHALL WRITE RECORD decision TO MODULE Memory DURING RECORD session.
+AGENT SHALL WRITE RECORD summary TO MODULE Memory 'at EXIT RECORD session.
+</trl>
+
+Memory is how you persist context across sessions. Decisions, preferences, project state, and pointers to external systems — stored as markdown files, indexed by MEMORY.md.
+
+---
+
+## Memory Types
+
+<trl>
+DEFINE "user" AS RECORD 'for PARTY human CONTAINS RECORD role AND RECORD preference AND RECORD expertise.
+DEFINE "feedback" AS RECORD 'for RECORD correction OR RECORD confirmation.
+DEFINE "project" AS RECORD 'for RECORD decision OR RECORD status OR RECORD deadline.
+DEFINE "reference" AS RECORD 'for ENDPOINT external_system.
+</trl>
+
+| Type | Save When | Example |
+|------|-----------|---------|
+| **user** | You learn about their role or preferences | "User is a data scientist focused on observability" |
+| **feedback** | They correct you OR confirm a non-obvious approach | "Don't mock the database — use real DB in tests" |
+| **project** | You learn who does what, why, or by when | "Merge freeze 2026-03-05 for mobile release" |
+| **reference** | You learn about external resources | "Pipeline bugs tracked in Linear project INGEST" |
+
+### User Memories
+
+<trl>
+AGENT SHALL WRITE RECORD user WHEN AGENT LEARN RECORD role OR RECORD preference OR RECORD expertise 'of PARTY human.
+RECORD user SHALL HELP AGENT TAILOR RECORD response TO PARTY human.
+</trl>
+
+Who the human is. Their role, expertise, how they like to work. A senior engineer gets different explanations than a student. A backend developer gets frontend concepts explained through backend analogies.
+
+### Feedback Memories
+
+<trl>
+AGENT SHALL WRITE RECORD feedback WHEN PARTY human CORRECT RECORD approach.
+AGENT SHALL WRITE RECORD feedback WHEN PARTY human CONFIRM RECORD non_obvious_approach.
+EACH RECORD feedback SHALL CONTAIN RECORD rule AND RECORD why AND RECORD how_to_apply.
+</trl>
+
+What the human has corrected or confirmed. Both matter — corrections prevent repeating mistakes, confirmations prevent abandoning validated approaches. Always record the **why** so you can judge edge cases.
+
+### Project Memories
+
+<trl>
+AGENT SHALL WRITE RECORD project WHEN AGENT LEARN RECORD decision OR RECORD deadline OR RECORD status.
+AGENT SHALL CONVERT ALL RECORD relative_date TO RECORD absolute_date 'before WRITE.
+EACH RECORD project SHALL CONTAIN RECORD fact AND RECORD why AND RECORD how_to_apply.
+</trl>
+
+What's happening in the project. Decisions, deadlines, who's doing what. Always convert relative dates ("Thursday") to absolute dates ("2026-03-05") so the memory stays useful.
+
+### Reference Memories
+
+<trl>
+AGENT SHALL WRITE RECORD reference WHEN AGENT LEARN RECORD location 'of RECORD external_resource.
+RECORD reference SHALL CONTAIN RECORD system AND RECORD purpose AND RECORD url_or_path.
+</trl>
+
+Where to find things outside the codebase. Bug trackers, dashboards, documentation, Slack channels.
+
+---
+
+## What NOT to Save
+
+<trl>
+NO AGENT SHALL WRITE RECORD memory 'for DATA code_pattern.
+NO AGENT SHALL WRITE RECORD memory 'for DATA git_history.
+NO AGENT SHALL WRITE RECORD memory 'for DATA 'that EXISTS 'in FILE CLAUDE.md.
+NO AGENT SHALL WRITE RECORD memory 'for RECORD ephemeral_task.
+NO AGENT SHALL WRITE RECORD memory 'for DATA file_path OR DATA architecture.
+</trl>
+
+Don't save what you can derive:
+- **Code patterns** — read the code
+- **Git history** — run git log
+- **File paths** — use glob/grep
+- **Architecture** — read the TRUGs
+- **Ephemeral state** — current task context dies with the session
+- **Anything in CLAUDE.md** — it's already loaded every session
+
+---
+
+## Memory File Format
+
+<trl>
+EACH RECORD memory SHALL PERSIST AS FILE 'with RECORD frontmatter AND RECORD content.
+RECORD frontmatter SHALL CONTAIN RECORD name AND RECORD description AND RECORD type.
+RECORD description SHALL 'be SPECIFIC — USED TO DECIDE RECORD relevance 'in FUTURE SESSION.
+</trl>
+
+```markdown
+---
+name: short title
+description: one-line description — be specific, this decides relevance
+type: user|feedback|project|reference
+---
+
+Content here.
+
+**Why:** reason for the decision
+**How to apply:** when this should influence future work
+```
+
+---
+
+## MEMORY.md Index
+
+<trl>
+FILE MEMORY.md SHALL CONTAIN A RECORD pointer 'for EACH RECORD memory.
+EACH RECORD pointer SHALL 'be LESS_THAN 150 STRING characters.
+FILE MEMORY.md SHALL 'be ORGANIZED BY RECORD type.
+AGENT SHALL UPDATE FILE MEMORY.md WHEN AGENT CREATE OR DELETE RECORD memory.
+</trl>
+
+MEMORY.md is an index, not a memory. One line per entry, under 150 characters. Organized by type.
+
+```markdown
+# Memory Index
+
+## User
+- [user_role.md](user_role.md) — Senior backend engineer, new to React
+
+## Feedback
+- [feedback_no_mocks.md](feedback_no_mocks.md) — Integration tests hit real DB, not mocks
+
+## Project
+- [project_freeze.md](project_freeze.md) — Merge freeze 2026-03-05 for mobile release
+
+## Reference
+- [reference_linear.md](reference_linear.md) — Pipeline bugs in Linear project "INGEST"
+```
+
+---
+
+## Session Lifecycle
+
+<trl>
+AGENT SHALL READ FILE MEMORY.md 'at ENTRY RECORD session.
+AGENT SHALL WRITE RECORD decision TO MODULE Memory WHEN RECORD decision EXISTS.
+AGENT SHALL WRITE RECORD session_summary 'at EXIT RECORD session.
+AGENT SHALL WRITE RECORD pointer TO FILE MEMORY.md 'for EACH NEW RECORD memory.
+</trl>
+
+### Session Start
+
+Read MEMORY.md. Load relevant memories based on the task at hand. Don't load everything — load what's relevant.
+
+### During Session
+
+Save memories as they happen. When the human makes a decision, save it. When they correct you, save the feedback. Don't batch — save immediately.
+
+### Session End
+
+Write a session summary: what was accomplished, what decisions were made, what's left to do. Update MEMORY.md with any new entries.
+
+---
+
+## Memory Hygiene
+
+<trl>
+AGENT SHALL_NOT WRITE RECORD memory 'that DUPLICATES EXISTING RECORD memory.
+AGENT SHALL UPDATE RECORD memory WHEN RECORD fact CHANGES.
+AGENT SHALL DELETE RECORD memory WHEN RECORD fact 'is NO_LONGER VALID.
+AGENT SHALL VERIFY RECORD memory 'before RECOMMEND RECORD action BASED_ON RECORD memory.
+</trl>
+
+- **No duplicates** — check before writing. Update existing memories instead.
+- **Update stale memories** — facts change. When they do, update the memory.
+- **Delete obsolete memories** — if a decision was reversed or a deadline passed, remove it.
+- **Verify before acting** — a memory that names a file or function is a claim about the past. Check that it still exists before recommending it.
+
+See [EXAMPLE_MEMORY.md](EXAMPLE_MEMORY.md) for a starter index.

--- a/installers/npm/templates/MEMORY/EXAMPLE_MEMORY.md
+++ b/installers/npm/templates/MEMORY/EXAMPLE_MEMORY.md
@@ -1,0 +1,14 @@
+# Memory Index
+
+## User
+- [user_role.md](user_role.md) — Senior backend engineer, new to React frontend
+
+## Feedback
+- [feedback_no_mocks.md](feedback_no_mocks.md) — Integration tests must hit real DB, not mocks
+- [feedback_single_pr.md](feedback_single_pr.md) — Prefer bundled PRs over many small ones for refactors
+
+## Project
+- [project_release_freeze.md](project_release_freeze.md) — Merge freeze 2026-03-05 for mobile release cut
+
+## Reference
+- [reference_linear_bugs.md](reference_linear_bugs.md) — Pipeline bugs tracked in Linear project "INGEST"

--- a/installers/npm/templates/MEMORY/README.md
+++ b/installers/npm/templates/MEMORY/README.md
@@ -1,0 +1,39 @@
+# Memory — Persistent Context Across Sessions
+
+Memory lets your LLM remember decisions, preferences, and project state between conversations. No more repeating yourself.
+
+## When to Use
+
+Every project benefits from memory. It's lightweight — a few markdown files that accumulate over time.
+
+## How It Works
+
+Memory is a folder of markdown files indexed by `MEMORY.md`:
+
+```
+MEMORY/
+  MEMORY.md              ← Index (one-line pointers)
+  user_role.md           ← Who you are
+  feedback_no_mocks.md   ← What you've corrected
+  project_freeze.md      ← What's happening
+  reference_linear.md    ← Where to find things
+```
+
+Four memory types:
+
+| Type | Save When | Example |
+|------|-----------|---------|
+| **user** | You learn about their role or preferences | "Senior backend engineer, new to React" |
+| **feedback** | They correct or confirm an approach | "Don't mock the database in tests" |
+| **project** | You learn who/what/why/when | "Merge freeze starts March 5" |
+| **reference** | You learn about external resources | "Bugs tracked in Linear project INGEST" |
+
+Your LLM reads `MEMORY.md` at session start. Saves new memories when decisions are made. Updates stale memories when things change.
+
+## Key Rule
+
+Memory stores what can't be derived from code or git history. Don't save file paths, architecture, or code patterns — those belong in the code. Save the *why* behind decisions, user preferences, and pointers to external systems.
+
+## Example
+
+See [EXAMPLE_MEMORY.md](EXAMPLE_MEMORY.md) for a starter index and the format for individual memory files.

--- a/installers/npm/templates/SKILLS/AGENT.md
+++ b/installers/npm/templates/SKILLS/AGENT.md
@@ -1,0 +1,367 @@
+# Skills — Agent Instructions
+
+<trl>
+DEFINE "Skill" AS FUNCTION.
+EACH FUNCTION Skill CONTAINS RECORD name AND RECORD description AND RECORD input AND RECORD output.
+AGENT SHALL EXECUTE FUNCTION Skill WHEN PARTY human REQUESTS RECORD name.
+EACH FUNCTION Skill SHALL EXECUTE STRICTLY A RECORD specification.
+EACH FUNCTION Skill SHALL PRODUCE RECORD output THEN RESPOND TO PARTY human.
+</trl>
+
+Skills are named actions an agent can execute on command. Each skill has one job, one input, one output. Primitives do one thing. Compounds sequence primitives with HITM gates between stages.
+
+---
+
+## Primitive vs Compound
+
+<trl>
+DEFINE "primitive" AS FUNCTION 'that CONTAINS EXACTLY A RECORD action.
+DEFINE "compound" AS FUNCTION 'that CONTAINS MULTIPLE FUNCTION primitive SEQUENTIAL.
+EACH FUNCTION primitive SHALL PRODUCE RECORD output THEN RESPOND TO PARTY human.
+EACH FUNCTION compound SHALL EXECUTE EACH FUNCTION primitive SEQUENTIAL.
+FUNCTION compound MAY REQUIRE PARTY human APPROVE RESULT 'at RECORD hitm_gate 'between FUNCTION primitive.
+</trl>
+
+A **primitive** does one atomic thing — read a file, run a command, write a node, send an email. It cannot be decomposed further.
+
+A **compound** sequences primitives. Between stages, it may pause for human approval (HITM gate). Compounds are how agents perform multi-step workflows autonomously.
+
+The rule: if a skill contains `THEN`, it is compound. If it does not, it is primitive.
+
+---
+
+## Primitive Skills
+
+### Git Primitives
+
+<trl>
+DEFINE "git-status" AS FUNCTION.
+FUNCTION git-status SHALL READ DATA working_tree THEN RESPOND 'with RECORD uncommitted AND RECORD unpushed.
+</trl>
+
+Reports uncommitted changes and unpushed commits. No side effects.
+
+<trl>
+DEFINE "git-commit" AS FUNCTION.
+FUNCTION git-commit SHALL REQUIRE RECORD message FROM PARTY human.
+FUNCTION git-commit SHALL WRITE ALL RECORD staged_change TO DATA repository 'with RECORD message.
+FUNCTION git-commit SHALL_NOT WRITE TO ENDPOINT main.
+FUNCTION git-commit SHALL_NOT WRITE TO ENDPOINT master.
+</trl>
+
+Stage, commit, and push changes on the current branch. Never commits to main.
+
+<trl>
+DEFINE "git-pr" AS FUNCTION.
+FUNCTION git-pr SHALL CREATE RESOURCE pull_request FROM RECORD branch TO ENDPOINT main.
+FUNCTION git-pr SHALL SEND RESOURCE pull_request TO PARTY human THEN EXIT.
+PARTY human SHALL APPROVE RESOURCE pull_request THEN MERGE RESULT TO ENDPOINT main.
+AGENT SHALL_NOT MERGE RESOURCE pull_request.
+</trl>
+
+Create a pull request and return the URL. The agent stops — only the human merges.
+
+<trl>
+DEFINE "git-branch" AS FUNCTION.
+FUNCTION git-branch SHALL CREATE RESOURCE branch FROM ENDPOINT main.
+FUNCTION git-branch SHALL REQUIRE RECORD name 'that CONTAINS RECORD issue_number OR RECORD description.
+</trl>
+
+Create a feature branch from main. Branch name includes the issue number when one exists.
+
+---
+
+### GitHub Primitives
+
+<trl>
+DEFINE "gh-issues" AS FUNCTION.
+FUNCTION gh-issues SHALL READ ALL RECORD issue FROM ENDPOINT github 'with RECORD state AND RECORD count.
+FUNCTION gh-issues MAY READ A RECORD issue BY RECORD number THEN RESPOND 'with RECORD title AND RECORD state AND RECORD labels.
+</trl>
+
+List open issues with count, or view a single issue by number.
+
+<trl>
+DEFINE "gh-prs" AS FUNCTION.
+FUNCTION gh-prs SHALL READ ALL RESOURCE pull_request FROM ENDPOINT github 'with RECORD state.
+FUNCTION gh-prs MAY READ RECORD diff FROM A RESOURCE pull_request BY RECORD number.
+</trl>
+
+List pull requests (open or merged), or get the file diff from a specific PR.
+
+---
+
+### TRUG Graph Primitives
+
+<trl>
+DEFINE "trug-sync" AS FUNCTION.
+FUNCTION trug-sync SHALL READ DATA filesystem THEN WRITE RECORD node 'for EACH NEW FILE TO FILE folder.trug.json.
+FUNCTION trug-sync SHALL VALIDATE EACH RECORD node SUBJECT_TO DATA filesystem.
+FUNCTION trug-sync SHALL MARK RECORD node AS PENDING IF FILE 'is 'not FOUND.
+FUNCTION trug-sync SHALL_NOT REPLACE ANY RECORD node.
+</trl>
+
+Run `trugs-folder-sync` on a folder. Adds nodes for new files, marks missing files stale. Never removes nodes.
+
+<trl>
+DEFINE "trug-check" AS FUNCTION.
+FUNCTION trug-check SHALL VALIDATE FILE folder.trug.json SUBJECT_TO RECORD rule.
+FUNCTION trug-check SHALL RESPOND 'with RECORD result AS VALID OR INVALID.
+IF RECORD result 'is INVALID THEN FUNCTION trug-check SHALL RESPOND 'with EACH RECORD error.
+</trl>
+
+Run `trugs-folder-check` to validate a folder.trug.json against structural rules. Returns pass/fail with error details.
+
+<trl>
+DEFINE "trug-clean" AS FUNCTION.
+FUNCTION trug-clean SHALL READ FILE folder.trug.json THEN FILTER ALL RECORD edge 'where RECORD from_id OR RECORD to_id 'is INVALID.
+FUNCTION trug-clean SHALL FILTER ALL RECORD node 'where RECORD stale EQUALS BOOLEAN 'true AND NO RECORD edge REFERENCES RECORD node.
+FUNCTION trug-clean SHALL VALIDATE EACH RECORD path SUBJECT_TO DATA filesystem.
+FUNCTION trug-clean SHALL MARK RECORD node AS PENDING IF RECORD path 'is INVALID.
+PARTY human SHALL APPROVE RESULT 'before FUNCTION trug-clean SHALL WRITE TO FILE folder.trug.json.
+</trl>
+
+Remove orphaned edges (dangling references), remove dead stale nodes (no remaining edges), mark nodes with broken paths. Presents findings for HITM approval before saving.
+
+<trl>
+DEFINE "trug-edge" AS FUNCTION.
+FUNCTION trug-edge SHALL REQUIRE RECORD from_file.
+FUNCTION trug-edge MAY REQUIRE RECORD to_file AND RECORD relation.
+IF RECORD to_file 'is 'not PROVIDED THEN FUNCTION trug-edge SHALL READ RECORD from_file THEN RESPOND 'with EACH RECORD proposed_edge.
+PARTY human SHALL APPROVE EACH RECORD proposed_edge 'before WRITE.
+FUNCTION trug-edge SHALL WRITE RECORD edge TO FILE folder.trug.json.
+</trl>
+
+Add or infer edges. Three modes: smart (one file — infer everything), directed (two files — infer relation), explicit (all three specified). Always asks for approval in smart/directed mode.
+
+---
+
+### Memory Primitives
+
+<trl>
+DEFINE "memory-save" AS FUNCTION.
+FUNCTION memory-save SHALL REQUIRE RECORD content AND RECORD type AND RECORD name.
+RECORD type 'is "user" OR "feedback" OR "project" OR "reference".
+FUNCTION memory-save SHALL WRITE FILE memory_record TO NAMESPACE memory.
+FUNCTION memory-save SHALL WRITE RECORD pointer TO FILE MEMORY.md.
+</trl>
+
+Write a memory file with frontmatter (name, description, type) and add a one-line pointer to MEMORY.md. One memory per call.
+
+<trl>
+DEFINE "memory-read" AS FUNCTION.
+FUNCTION memory-read SHALL READ FILE MEMORY.md THEN RESPOND 'with RECORD index.
+FUNCTION memory-read MAY READ FILE memory_record BY RECORD name.
+</trl>
+
+Read the memory index or a specific memory file. Used at session start to load context.
+
+---
+
+### EPIC Primitives
+
+<trl>
+DEFINE "epic-read" AS FUNCTION.
+FUNCTION epic-read SHALL READ FILE project.trug.json THEN RESPOND 'with DATA present_plan AND DATA portfolio_status AND DATA critical_path.
+FUNCTION epic-read MAY READ FILE epic.trug.json 'for RECORD business_context.
+</trl>
+
+Read the EPIC tracker — present plan, critical path, active issues, portfolio status. Optionally reads business epic if accessible.
+
+<trl>
+DEFINE "epic-sync" AS FUNCTION.
+FUNCTION epic-sync SHALL READ EACH RECORD task FROM FILE project.trug.json.
+FUNCTION epic-sync SHALL VALIDATE EACH RECORD task SUBJECT_TO ENDPOINT github 'by RECORD issue_number.
+IF RECORD task RECORD status 'is INVALID THEN FUNCTION epic-sync SHALL WRITE RECORD status TO FILE project.trug.json.
+</trl>
+
+Sync EPIC task node statuses with GitHub issue states. Updates status, pr_number, completed_date for any task that has drifted from reality.
+
+<trl>
+DEFINE "epic-portfolio" AS FUNCTION.
+FUNCTION epic-portfolio SHALL READ DATA filesystem THEN VALIDATE EACH RECORD folder SUBJECT_TO DATA portfolio_status.
+IF RECORD folder 'is NEW THEN FUNCTION epic-portfolio SHALL WRITE RECORD folder TO DATA portfolio_status.
+IF RECORD folder RECORD phase 'is INVALID THEN FUNCTION epic-portfolio SHALL WRITE RECORD phase.
+</trl>
+
+Update the portfolio_status node in the EPIC. Adds new top-level folders, updates phase for modified folders, verifies TRACKED_BY edges.
+
+---
+
+### Decision Primitive
+
+<trl>
+DEFINE "decisions" AS FUNCTION.
+FUNCTION decisions SHALL READ DATA conversation THEN FILTER ALL RECORD decision.
+RECORD decision 'is RECORD architecture_choice OR RECORD rule_change OR RECORD assumption_change OR RECORD surprising_finding OR RECORD priority_change.
+RECORD decision 'is 'not RECORD routine_code_change OR RECORD bug_fix OR RECORD file_rename.
+FUNCTION decisions SHALL RESPOND 'with EACH RECORD decision TO PARTY human.
+PARTY human SHALL APPROVE EACH RECORD decision 'before FUNCTION memory-save SHALL EXECUTE.
+</trl>
+
+Mine the current conversation for key decisions — architecture choices, new rules, changed assumptions, surprising findings, scope changes. Present to the human for approval, then save each approved decision via `/memory-save`.
+
+---
+
+### Worktree Primitives
+
+<trl>
+DEFINE "worktree-create" AS FUNCTION.
+FUNCTION worktree-create SHALL REQUIRE RECORD issue_number.
+FUNCTION worktree-create SHALL CREATE RESOURCE worktree FROM ENDPOINT main 'for RECORD issue_number.
+FUNCTION worktree-create SHALL_NOT REPLACE ANY RESOURCE worktree.
+</trl>
+
+Create a git worktree for an issue. Each worktree gets its own directory and branch — isolated git state for concurrent development.
+
+<trl>
+DEFINE "worktree-list" AS FUNCTION.
+FUNCTION worktree-list SHALL READ ALL RESOURCE worktree THEN RESPOND 'with EACH RECORD path AND RECORD branch AND RECORD status.
+</trl>
+
+List all active worktrees with their branch and dirty/clean status.
+
+<trl>
+DEFINE "worktree-remove" AS FUNCTION.
+FUNCTION worktree-remove SHALL REQUIRE RECORD issue_number.
+IF RESOURCE worktree CONTAINS RECORD uncommitted_change THEN PARTY human SHALL APPROVE 'before FUNCTION worktree-remove SHALL EXECUTE.
+FUNCTION worktree-remove SHALL REMOVE RESOURCE worktree 'for RECORD issue_number.
+</trl>
+
+Remove a worktree. Warns and asks for approval if uncommitted changes exist.
+
+---
+
+## Compound Skills — Composition
+
+<trl>
+DEFINE "compound" AS FUNCTION 'that CONTAINS MULTIPLE FUNCTION primitive SEQUENTIAL.
+EACH FUNCTION compound SHALL DECLARE EACH FUNCTION primitive 'it CONTAINS.
+FUNCTION compound MAY DEFINE RECORD hitm_gate 'between ANY FUNCTION primitive.
+RECORD hitm_gate SHALL REQUIRE PARTY human APPROVE RESULT 'before FUNCTION compound CONTINUES.
+</trl>
+
+A compound skill is a declared sequence of primitives. HITM gates are inserted where the human must approve before the agent continues. The compound skill definition IS the sequence — no hidden logic.
+
+---
+
+### Example: `/session-open`
+
+<trl>
+DEFINE "session-open" AS FUNCTION compound.
+FUNCTION session-open CONTAINS FUNCTION memory-read THEN FUNCTION epic-read THEN FUNCTION gh-issues THEN FUNCTION gh-prs THEN FUNCTION worktree-list.
+FUNCTION memory-read SHALL READ RECORD session_summary FROM NAMESPACE memory.
+FUNCTION epic-read SHALL READ DATA present_plan FROM FILE project.trug.json.
+FUNCTION gh-issues SHALL READ RECORD count FROM ENDPOINT github.
+FUNCTION gh-prs SHALL READ ALL RESOURCE pull_request 'with RECORD state 'is "open".
+FUNCTION worktree-list SHALL READ ALL RESOURCE worktree.
+FUNCTION session-open SHALL RESPOND TO PARTY human 'with RECORD overview AND RECORD suggested_next_steps.
+PARTY human SHALL APPROVE RECORD direction 'before AGENT CONTINUES.
+</trl>
+
+**Sequence:** Load last session from memory. Read EPIC for current plan and priorities. Count open issues. List open PRs. List worktrees. Present overview and suggest next steps. Wait for the human to choose direction.
+
+---
+
+### Example: `/session-update`
+
+<trl>
+DEFINE "session-update" AS FUNCTION compound.
+FUNCTION session-update CONTAINS FUNCTION git-status THEN FUNCTION git-commit THEN FUNCTION decisions THEN FUNCTION memory-save THEN FUNCTION trug-edge THEN FUNCTION epic-sync THEN FUNCTION epic-portfolio THEN FUNCTION trug-sync THEN FUNCTION git-commit THEN FUNCTION git-pr.
+FUNCTION git-status SHALL READ DATA working_tree.
+IF DATA working_tree CONTAINS RECORD uncommitted_change THEN FUNCTION git-commit SHALL EXECUTE.
+FUNCTION decisions SHALL READ DATA conversation THEN RESPOND 'with EACH RECORD decision.
+RECORD hitm_gate SHALL REQUIRE PARTY human APPROVE EACH RECORD decision.
+FUNCTION memory-save SHALL WRITE EACH RECORD decision TO NAMESPACE memory.
+FUNCTION trug-edge SHALL READ EACH RECORD merged_pr THEN WRITE RECORD edge TO FILE folder.trug.json.
+FUNCTION epic-sync SHALL VALIDATE EACH RECORD task SUBJECT_TO ENDPOINT github.
+FUNCTION epic-portfolio SHALL VALIDATE DATA portfolio_status SUBJECT_TO DATA filesystem.
+FUNCTION trug-sync SHALL EXECUTE 'on EACH RECORD modified_folder.
+FUNCTION git-commit SHALL WRITE ALL RECORD change 'with RECORD message "chore(maintenance)".
+FUNCTION git-pr SHALL CREATE RESOURCE pull_request THEN SEND TO PARTY human.
+</trl>
+
+**Sequence:** Check for uncommitted work — commit and push if needed. Mine conversation for decisions — present for HITM approval. Save approved decisions to memory. Create edges from merged PRs to code nodes. Sync EPIC task statuses with GitHub. Update portfolio status. Run folder-sync on modified folders. Commit all maintenance changes. Create PR — human merges.
+
+---
+
+### Example: `/session-close`
+
+<trl>
+DEFINE "session-close" AS FUNCTION compound.
+FUNCTION session-close CONTAINS FUNCTION session-update THEN FUNCTION memory-save THEN FUNCTION trug-clean THEN FUNCTION epic-sync THEN FUNCTION trug-check THEN FUNCTION worktree-remove THEN FUNCTION git-commit THEN FUNCTION git-pr.
+FUNCTION session-update SHALL EXECUTE 'without FUNCTION git-pr.
+FUNCTION memory-save SHALL WRITE RECORD session_summary TO NAMESPACE memory.
+FUNCTION trug-clean SHALL EXECUTE 'on ALL FILE folder.trug.json.
+RECORD hitm_gate SHALL REQUIRE PARTY human APPROVE RESULT 'of FUNCTION trug-clean.
+FUNCTION epic-sync SHALL WRITE RECORD total_open_issues AND RECORD last_updated TO FILE project.trug.json.
+FUNCTION trug-check SHALL VALIDATE ALL FILE folder.trug.json THEN RESPOND 'with RECORD result.
+FUNCTION worktree-remove SHALL REMOVE EACH RESOURCE worktree 'where RECORD branch 'is MERGED.
+FUNCTION git-commit SHALL WRITE ALL RECORD change 'with RECORD message "chore(stop)".
+FUNCTION git-pr SHALL CREATE RESOURCE pull_request THEN SEND TO PARTY human.
+</trl>
+
+**Sequence:** Run full session-update (without its own PR). Write session summary to memory. Clean all TRUG graphs — remove orphaned edges, stale nodes, broken paths (HITM gate). Sync EPIC issue counts. Validate all TRUGs. Remove merged worktrees. Commit everything. Create single PR — human merges.
+
+---
+
+## Building New Compounds
+
+<trl>
+AGENT MAY DEFINE NEW FUNCTION compound BY COMPOSE EXISTING FUNCTION primitive.
+EACH NEW FUNCTION compound SHALL DECLARE EACH FUNCTION primitive 'it CONTAINS.
+EACH NEW FUNCTION compound SHALL DEFINE RECORD hitm_gate 'where PARTY human APPROVAL 'is REQUIRED.
+AGENT SHALL_NOT DEFINE FUNCTION primitive 'that CONTAINS FUNCTION primitive.
+AGENT MAY DEFINE FUNCTION compound 'that CONTAINS FUNCTION compound.
+</trl>
+
+To create a new compound skill:
+
+1. Identify the primitives you need from the catalog above
+2. Declare the sequence with `CONTAINS ... THEN ... THEN ...`
+3. Insert HITM gates where the human must approve before continuing
+4. A primitive never contains another primitive — it is atomic
+5. A compound may contain other compounds (nesting is allowed)
+
+### Example: Building a hypothetical `/deploy-check`
+
+<trl>
+DEFINE "deploy-check" AS FUNCTION compound.
+FUNCTION deploy-check CONTAINS FUNCTION trug-check THEN FUNCTION trug-sync THEN FUNCTION epic-sync THEN FUNCTION git-status.
+FUNCTION trug-check SHALL VALIDATE ALL FILE folder.trug.json.
+IF RECORD result 'is INVALID THEN FUNCTION deploy-check SHALL RESPOND 'with EACH RECORD error THEN EXIT.
+FUNCTION trug-sync SHALL EXECUTE 'on ALL RECORD folder.
+FUNCTION epic-sync SHALL VALIDATE EACH RECORD task SUBJECT_TO ENDPOINT github.
+FUNCTION git-status SHALL VALIDATE NO RECORD uncommitted_change EXISTS.
+FUNCTION deploy-check SHALL RESPOND 'with RECORD ready AS BOOLEAN.
+</trl>
+
+**Sequence:** Validate all TRUGs — stop if any fail. Sync all folders. Sync EPIC with GitHub. Verify no uncommitted changes. Report ready/not-ready.
+
+---
+
+## Skill File Format
+
+<trl>
+EACH FUNCTION Skill SHALL 'be DEFINED 'in FILE SKILL.md 'in NAMESPACE .claude/skills/RECORD name/.
+FILE SKILL.md SHALL CONTAIN RECORD frontmatter 'with RECORD name AND RECORD description.
+FILE SKILL.md SHALL CONTAIN RECORD specification 'that GOVERNS AGENT EXECUTION.
+</trl>
+
+Each skill lives at `.claude/skills/<name>/SKILL.md`. The file contains:
+
+1. **Frontmatter** — name and one-line description
+2. **Specification** — the exact steps the agent executes
+
+```markdown
+---
+name: skill-name
+description: One-line description of what the skill does
+---
+
+# /skill-name — Title
+
+Steps the agent executes...
+```
+
+The human invokes a skill by typing `/<name>` in the conversation. The agent loads the SKILL.md and executes strictly what it specifies.

--- a/installers/npm/templates/SKILLS/README.md
+++ b/installers/npm/templates/SKILLS/README.md
@@ -1,0 +1,42 @@
+# Skills — Composable Agent Actions
+
+Skills are named actions your LLM executes on command. Type `/skill-name` and the agent does exactly what the skill specifies.
+
+## How It Works
+
+Two kinds of skills:
+
+| Kind | Rule | Example |
+|------|------|---------|
+| **Primitive** | One action, one output, no decomposition | `/git-status`, `/trug-check`, `/email-fetch` |
+| **Compound** | Sequence of primitives with HITM gates | `/session-open`, `/session-close`, `/email-triage` |
+
+## The 19 Primitives
+
+| Category | Skills |
+|----------|--------|
+| **Git** | `git-status`, `git-commit`, `git-pr`, `git-branch` |
+| **GitHub** | `gh-issues`, `gh-prs` |
+| **TRUG Graph** | `trug-sync`, `trug-check`, `trug-clean`, `trug-edge` |
+| **Memory** | `memory-save`, `memory-read` |
+| **EPIC** | `epic-read`, `epic-sync`, `epic-portfolio` |
+| **Decisions** | `decisions` |
+| **Worktree** | `worktree-create`, `worktree-list`, `worktree-remove` |
+
+## Compound Examples
+
+```
+/session-open  = memory-read > epic-read > gh-issues > gh-prs > worktree-list
+/session-update = git-status > git-commit > decisions > memory-save > trug-edge > epic-sync > epic-portfolio > trug-sync > git-commit > git-pr
+/session-close = session-update > memory-save > trug-clean > epic-sync > trug-check > worktree-remove > git-commit > git-pr
+```
+
+The `>` means "then." Where a human must approve before continuing, the compound inserts a HITM gate.
+
+## Key Rule
+
+Primitives are atomic — they never contain other primitives. Compounds sequence primitives. You can build new compounds by composing existing primitives. You can nest compounds inside other compounds.
+
+## Full Specification
+
+See [AGENT.md](AGENT.md) for the complete TRL definitions of all 19 primitives and 3 compound examples.

--- a/installers/npm/templates/TRUGGING/AGENT.md
+++ b/installers/npm/templates/TRUGGING/AGENT.md
@@ -1,0 +1,312 @@
+# Trugging — Agent Instructions
+
+<trl>
+DEFINE "Trugging" AS PIPELINE CONTAINS STAGE system AND STAGE component AND STAGE file_header AND STAGE inline.
+STAGE system SHALL PRODUCE DATA graph AS FILE project.trug.json.
+STAGE component SHALL PRODUCE DATA graph AS FILE folder.trug.json.
+STAGE file_header SHALL PRODUCE RECORD trl_block 'at ENTRY FILE.
+STAGE inline SHALL PRODUCE RECORD trl_block 'at ENTRY FUNCTION.
+EACH STAGE SHALL EXECUTE SEQUENTIAL FROM STAGE system TO STAGE inline.
+</trl>
+
+Trugging is how you describe a program using TRUGs and TRL. Four levels, top-down. Graphs for structure, sentences for behavior.
+
+---
+
+## Level 1: System — `project.trug.json`
+
+<trl>
+AGENT SHALL CREATE FILE project.trug.json 'at ENTRY NAMESPACE project.
+EACH SERVICE SHALL 'be A DATA node 'in FILE project.trug.json.
+EACH STREAM SHALL 'be A DATA node 'in FILE project.trug.json.
+EACH MODULE SHALL 'be A DATA node IF MODULE 'is ENTRY OR EXIT.
+EACH DATA node SHALL CONTAIN RECORD name AND RECORD type AND RECORD dimension.
+AGENT SHALL CREATE DATA edge 'for EACH RECORD dependency 'between DATA node.
+AGENT SHALL_NOT CREATE DATA node 'for RECORD implementation_detail.
+</trl>
+
+### What Goes In
+
+Nodes: services, databases, message queues, external APIs, top-level modules. Things that exist independently and have names a human would recognize.
+
+Edges: `DEPENDS_ON`, `READS`, `WRITES`, `FEEDS`, `AUTHENTICATES`, `IMPLEMENTS`. How the big pieces connect.
+
+### What Stays Out
+
+Internal classes, helper functions, utility files. If it doesn't appear in an architecture diagram, it doesn't appear in the system TRUG.
+
+### Example
+
+```json
+{
+  "name": "My App",
+  "version": "1.0.0",
+  "type": "SYSTEM",
+  "dimensions": {
+    "system": {"description": "System architecture", "base_level": "BASE"}
+  },
+  "capabilities": {"extensions": [], "vocabularies": ["core_v1.0.0"], "profiles": []},
+  "nodes": [
+    {"id": "api", "type": "SERVICE", "properties": {"name": "API Server", "language": "python"}, "parent_id": null, "contains": ["auth", "handlers"], "metric_level": "KILO_SERVICE", "dimension": "system"},
+    {"id": "auth", "type": "MODULE", "properties": {"name": "Auth Module"}, "parent_id": "api", "contains": [], "metric_level": "HECTO_MODULE", "dimension": "system"},
+    {"id": "handlers", "type": "MODULE", "properties": {"name": "Request Handlers"}, "parent_id": "api", "contains": [], "metric_level": "HECTO_MODULE", "dimension": "system"},
+    {"id": "db", "type": "STREAM", "properties": {"name": "PostgreSQL", "engine": "postgres"}, "parent_id": null, "contains": [], "metric_level": "KILO_STREAM", "dimension": "system"},
+    {"id": "queue", "type": "STREAM", "properties": {"name": "Task Queue", "engine": "redis"}, "parent_id": null, "contains": [], "metric_level": "KILO_STREAM", "dimension": "system"}
+  ],
+  "edges": [
+    {"from_id": "api", "to_id": "db", "relation": "READS"},
+    {"from_id": "api", "to_id": "db", "relation": "WRITES"},
+    {"from_id": "api", "to_id": "queue", "relation": "WRITES"},
+    {"from_id": "api", "to_id": "auth", "relation": "DEPENDS_ON"},
+    {"from_id": "handlers", "to_id": "auth", "relation": "DEPENDS_ON"}
+  ]
+}
+```
+
+---
+
+## Level 2: Component — `folder.trug.json`
+
+<trl>
+AGENT SHALL CREATE FILE folder.trug.json 'at ENTRY EACH MODULE.
+EACH FILE 'in MODULE SHALL 'be A DATA node.
+EACH SERVICE OR FUNCTION 'that 'is PUBLIC SHALL 'be A DATA node.
+AGENT SHALL CREATE DATA edge 'for EACH RECORD import 'between FILE.
+AGENT SHALL CREATE DATA edge 'for EACH RECORD call 'between SERVICE OR FUNCTION.
+AGENT SHALL_NOT CREATE DATA node 'for PRIVATE FUNCTION UNLESS FUNCTION 'is CRITICAL.
+</trl>
+
+### What Goes In
+
+Nodes: every file in the folder, plus public classes/services/interfaces that other modules depend on.
+
+Edges: `IMPORTS`, `CALLS`, `IMPLEMENTS`, `EXTENDS`, `CONTAINS`. How the files and their exports relate.
+
+### What Stays Out
+
+Private helper functions, internal constants, implementation details that don't cross a file boundary.
+
+### Example
+
+```json
+{
+  "name": "Auth Module",
+  "version": "1.0.0",
+  "type": "MODULE",
+  "dimensions": {
+    "code": {"description": "Code structure", "base_level": "BASE"}
+  },
+  "capabilities": {"extensions": [], "vocabularies": ["core_v1.0.0"], "profiles": []},
+  "nodes": [
+    {"id": "handler", "type": "FILE", "properties": {"path": "handler.py"}, "parent_id": null, "contains": ["UserService"], "metric_level": "DEKA_FILE", "dimension": "code"},
+    {"id": "models", "type": "FILE", "properties": {"path": "models.py"}, "parent_id": null, "contains": ["User", "Token"], "metric_level": "DEKA_FILE", "dimension": "code"},
+    {"id": "middleware", "type": "FILE", "properties": {"path": "middleware.py"}, "parent_id": null, "contains": ["AuthMiddleware"], "metric_level": "DEKA_FILE", "dimension": "code"},
+    {"id": "UserService", "type": "SERVICE", "properties": {"name": "UserService"}, "parent_id": "handler", "contains": [], "metric_level": "BASE_SERVICE", "dimension": "code"},
+    {"id": "User", "type": "RECORD", "properties": {"name": "User"}, "parent_id": "models", "contains": [], "metric_level": "BASE_RECORD", "dimension": "code"},
+    {"id": "Token", "type": "RECORD", "properties": {"name": "Token"}, "parent_id": "models", "contains": [], "metric_level": "BASE_RECORD", "dimension": "code"},
+    {"id": "AuthMiddleware", "type": "FUNCTION", "properties": {"name": "AuthMiddleware"}, "parent_id": "middleware", "contains": [], "metric_level": "BASE_FUNCTION", "dimension": "code"}
+  ],
+  "edges": [
+    {"from_id": "handler", "to_id": "models", "relation": "IMPORTS"},
+    {"from_id": "middleware", "to_id": "models", "relation": "IMPORTS"},
+    {"from_id": "UserService", "to_id": "User", "relation": "READS"},
+    {"from_id": "UserService", "to_id": "Token", "relation": "VALIDATES"},
+    {"from_id": "AuthMiddleware", "to_id": "Token", "relation": "VALIDATES"}
+  ]
+}
+```
+
+---
+
+## Level 3: File Header — `<trl>` block
+
+<trl>
+AGENT SHALL WRITE RECORD trl_block 'at ENTRY EACH FILE 'that CONTAINS PUBLIC FUNCTION OR SERVICE.
+RECORD trl_block SHALL DESCRIBE ALL RECORD obligation 'for MODULE.
+RECORD trl_block SHALL DESCRIBE ALL RECORD prohibition 'for MODULE.
+RECORD trl_block SHALL DESCRIBE ALL RECORD interface 'that MODULE IMPLEMENTS OR DEPENDS_ON.
+AGENT SHALL_NOT DESCRIBE RECORD implementation_detail 'in RECORD trl_block.
+EACH RECORD trl_block SHALL CONTAIN 3 TO 8 RECORD sentence.
+</trl>
+
+### What Goes In
+
+Obligations (SHALL), prohibitions (SHALL_NOT), interfaces, error handling contracts. What the module promises to do and promises not to do.
+
+### What Stays Out
+
+How it works internally. The header describes the *contract*, not the *mechanism*. An agent reads the header to know what the module guarantees — not how it achieves those guarantees.
+
+### How to Write It
+
+<trl>
+AGENT SHALL IDENTIFY ALL PUBLIC FUNCTION 'in FILE.
+AGENT SHALL IDENTIFY ALL RECORD obligation — WHAT MUST FILE DO.
+AGENT SHALL IDENTIFY ALL RECORD prohibition — WHAT MUST FILE NOT DO.
+AGENT SHALL IDENTIFY ALL RECORD interface — WHAT DOES FILE DEPEND 'on OR EXPOSE.
+AGENT SHALL IDENTIFY ALL RECORD exception — WHAT CAN GO WRONG.
+AGENT SHALL WRITE EACH AS RECORD sentence 'in RECORD trl_block.
+</trl>
+
+### Example
+
+```python
+# <trl>
+# MODULE auth SHALL AUTHENTICATE ALL PARTY 'before GRANT ACCESS TO DATA.
+# MODULE auth SHALL READ DATA credential FROM ENDPOINT environment_variable.
+# MODULE auth SHALL_NOT WRITE DATA credential TO FILE OR STREAM log.
+# MODULE auth SHALL VALIDATE DATA token SUBJECT_TO INTERFACE jwt_schema
+#   THEN RETURN PARTY user OR THROW EXCEPTION auth_error.
+# IF DATA token 'is EXPIRED THEN MODULE auth SHALL DENY PARTY
+#   AND SEND ERROR TO PARTY caller.
+# </trl>
+
+import jwt
+from config import SECRET_KEY
+...
+```
+
+---
+
+## Level 4: Inline — `<trl>` in code comments
+
+<trl>
+AGENT SHALL WRITE RECORD trl_block 'before EACH FUNCTION 'that 'is PUBLIC OR CRITICAL.
+AGENT MAY WRITE RECORD trl_block 'before RECORD code_block 'that 'is COMPLEX.
+EACH INLINE RECORD trl_block SHALL CONTAIN 1 TO 3 RECORD sentence.
+RECORD trl_block SHALL DESCRIBE RECORD contract — INPUT AND OUTPUT AND EXCEPTION.
+AGENT SHALL_NOT WRITE RECORD trl_block 'for TRIVIAL FUNCTION.
+</trl>
+
+### What Goes In
+
+Function contracts: what it takes, what it returns, what it throws, and any non-obvious obligation. One to three sentences.
+
+### What Stays Out
+
+Trivial functions. A getter, a simple constructor, a one-line utility — these don't need TRL. If the function signature tells the whole story, don't repeat it in TRL.
+
+### When to Write Inline TRL
+
+<trl>
+AGENT SHALL WRITE INLINE RECORD trl_block IF FUNCTION 'is PUBLIC.
+AGENT SHALL WRITE INLINE RECORD trl_block IF FUNCTION CONTAINS RECORD side_effect.
+AGENT SHALL WRITE INLINE RECORD trl_block IF FUNCTION CONTAINS RECORD security OBLIGATION.
+AGENT SHALL WRITE INLINE RECORD trl_block IF FUNCTION CONTAINS RECORD retry OR RECORD timeout.
+AGENT MAY SKIP INLINE RECORD trl_block IF FUNCTION 'is PRIVATE AND TRIVIAL.
+</trl>
+
+### Example
+
+```python
+# <trl>FUNCTION validate_token SHALL VALIDATE DATA token SUBJECT_TO INTERFACE jwt_schema.
+#   IF DATA token 'is INVALID OR EXPIRED THEN THROW EXCEPTION auth_error.
+#   FUNCTION validate_token SHALL RETURN PARTY user 'with ACTIVE ACCESS.</trl>
+def validate_token(token: str) -> User:
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=["HS256"])
+    except jwt.ExpiredSignatureError:
+        raise AuthError("Token expired")
+    except jwt.InvalidTokenError:
+        raise AuthError("Invalid token")
+    return User.from_payload(payload)
+
+
+# <trl>FUNCTION send_welcome SHALL SEND MESSAGE welcome TO PARTY user
+#   THEN WRITE RECORD log. FUNCTION send_welcome SHALL RETRY BOUNDED 3.</trl>
+def send_welcome(user: User):
+    for attempt in range(3):
+        try:
+            email.send(user.email, WELCOME_TEMPLATE)
+            logger.info(f"Welcome sent to {user.id}")
+            return
+        except SMTPError:
+            if attempt == 2:
+                raise
+```
+
+---
+
+## The Boundary Rule
+
+<trl>
+DEFINE "boundary" AS ENTRY FILE.
+IF RECORD description 'is ABOVE ENTRY FILE THEN AGENT SHALL USE DATA graph.
+IF RECORD description 'is BELOW ENTRY FILE THEN AGENT SHALL USE RECORD trl_block.
+DATA graph SHALL DESCRIBE RECORD structure — WHAT EXISTS AND HOW IT CONNECTS.
+RECORD trl_block SHALL DESCRIBE RECORD behavior — WHAT MUST HAPPEN AND WHAT MUST NOT.
+</trl>
+
+| Level | Format | Describes | Agent Question |
+|-------|--------|-----------|----------------|
+| System | TRUG graph | Services, databases, top-level modules | What exists? |
+| Component | TRUG graph | Files, classes, public interfaces | What's inside this module? |
+| File header | TRL sentences | Module obligations and prohibitions | What are the contracts? |
+| Inline | TRL sentences | Function contracts and side effects | What does this function guarantee? |
+
+**Above the file: graph. Inside the file: sentences.**
+
+---
+
+## Trugging a Codebase — Step by Step
+
+<trl>
+AGENT SHALL EXECUTE STAGE system THEN STAGE component THEN STAGE file_header THEN STAGE inline.
+AGENT SHALL_NOT EXECUTE STAGE inline 'before STAGE system.
+EACH STAGE SHALL COMPLETE 'before NEXT STAGE BEGINS.
+</trl>
+
+### Step 1: System TRUG
+
+<trl>
+AGENT SHALL READ ALL FILE 'in NAMESPACE project 'at DEPTH 1.
+AGENT SHALL IDENTIFY ALL SERVICE AND STREAM AND MODULE.
+AGENT SHALL CREATE FILE project.trug.json 'with ALL DATA node AND DATA edge.
+AGENT SHALL VALIDATE FILE project.trug.json.
+</trl>
+
+Scan the project root. Identify the big pieces. Create `project.trug.json`. Validate.
+
+### Step 2: Component TRUGs
+
+<trl>
+AGENT SHALL READ EACH MODULE IDENTIFIED 'in STAGE system.
+'for EACH MODULE AGENT SHALL CREATE FILE folder.trug.json.
+AGENT SHALL VALIDATE EACH FILE folder.trug.json.
+</trl>
+
+For each major folder, create a `folder.trug.json`. Map files, public interfaces, imports, calls. Validate.
+
+### Step 3: File Headers
+
+<trl>
+AGENT SHALL READ EACH FILE 'that CONTAINS PUBLIC FUNCTION OR SERVICE.
+'for EACH FILE AGENT SHALL WRITE RECORD trl_block 'at ENTRY FILE.
+AGENT SHALL ASSERT RECORD trl_block CONTAINS RECORD obligation OR RECORD prohibition.
+</trl>
+
+For each non-trivial file, write a `<trl>` header. Cover obligations, prohibitions, interfaces, error contracts.
+
+### Step 4: Inline TRL
+
+<trl>
+AGENT SHALL READ EACH PUBLIC FUNCTION AND EACH CRITICAL FUNCTION.
+'for EACH FUNCTION AGENT SHALL WRITE INLINE RECORD trl_block.
+AGENT MAY SKIP TRIVIAL FUNCTION.
+</trl>
+
+For each public or critical function, write an inline `<trl>` comment. Cover inputs, outputs, exceptions, side effects.
+
+---
+
+## Maintaining TRUGs
+
+<trl>
+IF AGENT CREATE FILE THEN AGENT SHALL UPDATE FILE folder.trug.json.
+IF AGENT DELETE FILE THEN AGENT SHALL UPDATE FILE folder.trug.json.
+IF AGENT CREATE SERVICE OR MODULE THEN AGENT SHALL UPDATE FILE project.trug.json.
+IF AGENT MODIFY RECORD contract 'of FUNCTION THEN AGENT SHALL UPDATE INLINE RECORD trl_block.
+AGENT SHALL_NOT MODIFY RECORD trl_block WITHOUT MODIFYING RECORD code OR RECORD code WITHOUT MODIFYING RECORD trl_block.
+</trl>
+
+TRUGs and TRL stay in sync with code. When code changes, the description changes. When the description changes, the code changes. Drift between the two is a bug.

--- a/installers/npm/templates/TRUGGING/EXAMPLE_auth_module.md
+++ b/installers/npm/templates/TRUGGING/EXAMPLE_auth_module.md
@@ -1,0 +1,110 @@
+# Trugging Example: Auth Module
+
+A walkthrough of the 4-level Trugging methodology applied to an authentication module.
+
+---
+
+## Level 1: System TRUG — `project.trug.json`
+
+The auth module appears as one node in the system graph:
+
+```json
+{
+  "id": "auth",
+  "type": "MODULE",
+  "properties": {"name": "Auth Module", "language": "python"},
+  "parent_id": "api",
+  "contains": [],
+  "metric_level": "HECTO_MODULE",
+  "dimension": "system"
+}
+```
+
+Edges connect it to the rest of the system:
+
+```json
+{"from_id": "api", "to_id": "auth", "relation": "DEPENDS_ON"},
+{"from_id": "auth", "to_id": "db", "relation": "READS"}
+```
+
+**What an LLM learns:** auth exists, the API depends on it, it reads from the database.
+
+---
+
+## Level 2: Component TRUG — `auth/folder.trug.json`
+
+Inside the auth folder, each file and public interface is a node:
+
+```json
+{
+  "nodes": [
+    {"id": "handler", "type": "FILE", "properties": {"path": "handler.py", "purpose": "Request handlers — login, logout, token refresh"}, ...},
+    {"id": "models", "type": "FILE", "properties": {"path": "models.py", "purpose": "User and Token data models"}, ...},
+    {"id": "middleware", "type": "FILE", "properties": {"path": "middleware.py", "purpose": "Auth middleware — validates JWT on every request"}, ...},
+    {"id": "UserService", "type": "SERVICE", "properties": {"name": "UserService"}, "parent_id": "handler", ...},
+    {"id": "AuthMiddleware", "type": "FUNCTION", "properties": {"name": "AuthMiddleware"}, "parent_id": "middleware", ...}
+  ],
+  "edges": [
+    {"from_id": "handler", "to_id": "models", "relation": "IMPORTS"},
+    {"from_id": "middleware", "to_id": "models", "relation": "IMPORTS"},
+    {"from_id": "UserService", "to_id": "AuthMiddleware", "relation": "DEPENDS_ON"}
+  ]
+}
+```
+
+**What an LLM learns:** three files, how they import each other, UserService depends on AuthMiddleware.
+
+---
+
+## Level 3: File Header TRL — top of `auth/handler.py`
+
+```python
+# <trl>
+# MODULE auth SHALL AUTHENTICATE ALL PARTY 'before GRANT ACCESS TO DATA.
+# MODULE auth SHALL READ DATA credential FROM ENDPOINT environment_variable.
+# MODULE auth SHALL_NOT WRITE DATA credential TO FILE OR STREAM log.
+# MODULE auth SHALL VALIDATE DATA token SUBJECT_TO INTERFACE jwt_schema
+#   THEN RETURN PARTY user OR THROW EXCEPTION auth_error.
+# IF DATA token 'is EXPIRED THEN MODULE auth SHALL DENY PARTY
+#   AND SEND ERROR TO PARTY caller.
+# </trl>
+
+import jwt
+from config import SECRET_KEY
+from models import User
+```
+
+**What an LLM learns:** 5 obligations and prohibitions — authenticate before access, read creds from env vars, never log secrets, validate tokens or throw, handle expiration. All in 5 sentences.
+
+---
+
+## Level 4: Inline TRL — on `validate_token` function
+
+```python
+# <trl>FUNCTION validate_token SHALL VALIDATE DATA token SUBJECT_TO INTERFACE jwt_schema.
+#   IF DATA token 'is INVALID OR EXPIRED THEN THROW EXCEPTION auth_error.
+#   FUNCTION validate_token SHALL RETURN PARTY user 'with ACTIVE ACCESS.</trl>
+def validate_token(token: str) -> User:
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=["HS256"])
+    except jwt.ExpiredSignatureError:
+        raise AuthError("Token expired")
+    except jwt.InvalidTokenError:
+        raise AuthError("Invalid token")
+    return User.from_payload(payload)
+```
+
+**What an LLM learns:** this function's contract — validate JWT, throw on invalid/expired, return User. Can verify code matches, generate tests, detect drift.
+
+---
+
+## The Walkthrough
+
+An LLM fixing a bug in auth reads 4 things:
+
+1. `project.trug.json` → auth exists, API depends on it, it reads from DB
+2. `auth/folder.trug.json` → handler.py, models.py, middleware.py, their imports
+3. `auth/handler.py` header TRL → module obligations: authenticate, never log secrets, handle expiration
+4. Inline TRL on `validate_token` → function contract: validate JWT, throw on expired, return User
+
+System to function in 4 reads. No prose docs, no guessing, no asking.

--- a/installers/npm/templates/TRUGGING/README.md
+++ b/installers/npm/templates/TRUGGING/README.md
@@ -1,0 +1,52 @@
+# TRUGGING — How to Describe a Program with TRUGs and TRL
+
+Trugging is the methodology for describing a codebase at every level of granularity — from the whole system down to a single function. TRUGs (graphs) describe structure. TRL (sentences) describe behavior. Together they give an LLM a complete, machine-readable picture of your program without reading every line of code.
+
+## When to Use
+
+Any codebase that an LLM will work on repeatedly. The upfront cost is small — a JSON file per major folder, a few sentences per file. The payoff is that your LLM stops guessing architecture and starts navigating it.
+
+## Four Levels
+
+### Level 1: System — `project.trug.json`
+
+The whole program as a graph. Nodes are services, databases, external APIs, major modules. Edges are dependencies, data flows, ownership.
+
+Your LLM reads this to answer: *what exists and what connects to what?*
+
+### Level 2: Component — `folder.trug.json`
+
+Each major folder gets its own graph. Nodes are files, classes, key interfaces. Edges are imports, implementations, calls.
+
+Your LLM reads this to answer: *what's inside this module and how do the pieces fit together?*
+
+### Level 3: File Header — `<trl>` block at top of file
+
+A few TRL sentences describing what the module does, what it must do, and what it must not do. Obligations, not implementation details.
+
+Your LLM reads this to answer: *what are this module's contracts?*
+
+### Level 4: Inline — `<trl>` in code comments
+
+TRL sentences on critical functions or blocks. Compilable contracts that an LLM can verify against the code, generate tests from, or detect drift on.
+
+Your LLM reads this to answer: *what is this function's exact contract?*
+
+## The Boundary Rule
+
+Above the file boundary (system, folder): **use TRUGs**. You're mapping structure — things and relationships. Machines traverse it.
+
+Inside the file boundary (header, inline): **use TRL**. You're specifying behavior — actions and obligations. Humans read it, agents execute it.
+
+**TRUGs are nouns. TRL is verbs.**
+
+## Example Walkthrough
+
+An agent needs to fix a bug in the auth module:
+
+1. Reads `project.trug.json` — finds `auth`, sees it connects to `api` and `db`
+2. Reads `auth/folder.trug.json` — finds `handler.py`, `models.py`, sees `UserService` depends on `TokenValidator`
+3. Reads `auth/handler.py` header TRL — knows: must authenticate, must not log secrets, must handle expiration
+4. Reads inline TRL on `validate_token` — knows the function contract: validate JWT, throw on expired, return User
+
+Four reads. System to function. No prose docs, no guessing, no asking the human.

--- a/installers/npm/templates/WEB_HUB/AGENT.md
+++ b/installers/npm/templates/WEB_HUB/AGENT.md
@@ -1,0 +1,142 @@
+# WEB_HUB — Agent Instructions
+
+<trl>
+DEFINE "WEB_HUB" AS DATA graph 'for RECORD web_resource.
+EACH DATA node SHALL CONTAIN RECORD url AND RECORD purpose AND RECORD category.
+EACH DATA edge SHALL CONTAIN RECORD relation AND RECORD weight FROM 0.0 TO 1.0.
+AGENT SHALL READ DATA graph WEB_HUB TO NAVIGATE RECORD web_landscape.
+AGENT SHALL_NOT FETCH RECORD url UNLESS RECORD purpose MATCHES RECORD task.
+</trl>
+
+A WEB_HUB is a TRUG that indexes web resources — papers, repos, tools, articles, standards — organized into branches with weighted edges showing how things relate.
+
+---
+
+## Structure
+
+<trl>
+DEFINE "branch" AS MODULE CONTAINING RESOURCE node 'for A RECORD audience.
+EACH DATA graph WEB_HUB SHALL CONTAIN ONE OR MORE MODULE branch.
+EACH MODULE branch SHALL CONTAIN RESOURCE node 'with RECORD url AND RECORD purpose.
+DATA edge 'between RESOURCE SHALL CONTAIN RECORD weight AND RECORD relation.
+RECORD weight SHALL RANK RECORD relevance — HIGHER 'is MORE RELEVANT.
+</trl>
+
+A web hub has three levels:
+
+| Level | Type | Purpose |
+|-------|------|---------|
+| Root | FOLDER | The hub itself — contains branches |
+| Branch | MODULE | Audience-specific grouping of resources |
+| Resource | RESOURCE | A single URL with purpose and category |
+
+### Resource Node Properties
+
+<trl>
+EACH RESOURCE node SHALL CONTAIN RECORD name — TITLE 'of RESOURCE.
+EACH RESOURCE node SHALL CONTAIN RECORD url — EXACT RECORD address.
+EACH RESOURCE node SHALL CONTAIN RECORD purpose — A RECORD sentence EXPLAINING WHAT RESOURCE CONTAINS AND WHY IT MATTERS.
+EACH RESOURCE node SHALL CONTAIN RECORD category — PAPER OR REPO OR ARTICLE OR TOOL OR STANDARD OR GUIDE OR TEMPLATE OR INFLUENCER.
+</trl>
+
+The `purpose` field is the key — it tells you what the resource contains without fetching it. Read purposes to decide relevance before opening any URL.
+
+---
+
+## Edge Relations
+
+<trl>
+DEFINE "MOTIVATES" AS DATA edge — THIS RESOURCE IDENTIFIES A RECORD problem 'that TARGET SOLVES.
+DEFINE "CONTRASTS" AS DATA edge — THIS RESOURCE DOES RECORD similar_thing BUT DIFFERENTLY.
+DEFINE "COMPLEMENTS" AS DATA edge — THIS RESOURCE WORKS ALONGSIDE TARGET.
+DEFINE "CONTEXTUALIZES" AS DATA edge — THIS RESOURCE SHOWS THE RECORD landscape.
+DEFINE "EXTENDS" AS DATA edge — THIS RESOURCE BUILDS 'on TARGET.
+DEFINE "AMPLIFIES" AS DATA edge — THIS RESOURCE INCREASES RECORD reach 'of TARGET.
+DEFINE "IMPLEMENTS" AS DATA edge — THIS RESOURCE 'is AN IMPLEMENTATION 'of TARGET.
+DEFINE "FEEDS" AS DATA edge — BRANCH CONVERGES 'on TARGET.
+</trl>
+
+| Relation | Weight Range | Meaning |
+|----------|-------------|---------|
+| MOTIVATES | 0.6–0.95 | Resource identifies the problem your project solves |
+| CONTRASTS | 0.5–0.8 | Resource does something similar but different — competitive landscape |
+| COMPLEMENTS | 0.5–0.85 | Resource works alongside yours — integration opportunity |
+| CONTEXTUALIZES | 0.5–0.7 | Resource shows the broader landscape |
+| EXTENDS | 0.7–0.9 | Resource builds on another resource |
+| AMPLIFIES | 0.8–0.9 | Resource increases reach — influencers, channels |
+| IMPLEMENTS | 0.9–1.0 | Resource is a concrete implementation of a spec or paper |
+| FEEDS | 1.0 | Branch → convergence node (structural) |
+
+**Higher weight = stronger connection.** When traversing, follow high-weight edges first.
+
+---
+
+## How to Read a Web Hub
+
+<trl>
+AGENT SHALL READ DATA graph web.trug.json 'at ENTRY RECORD research_task.
+AGENT SHALL IDENTIFY ALL MODULE branch TO UNDERSTAND RECORD landscape_structure.
+AGENT SHALL FOLLOW DATA edge 'with RECORD weight ABOVE 0.8 FIRST.
+AGENT SHALL READ RECORD purpose 'on EACH RESOURCE 'before FETCH RECORD url.
+AGENT SHALL_NOT FETCH ALL RESOURCE — ONLY FETCH RECORD relevant RESOURCE.
+</trl>
+
+1. **Read the branches** — understand how resources are organized by audience
+2. **Follow high-weight edges** — these are the strongest connections
+3. **Read purposes** — decide relevance before fetching any URL
+4. **Traverse by relation type** — MOTIVATES edges find the problem, CONTRASTS edges find alternatives, COMPLEMENTS edges find integration partners
+
+---
+
+## How to Build a Web Hub
+
+<trl>
+AGENT SHALL IDENTIFY RECORD audience 'for EACH MODULE branch.
+'for EACH MODULE branch AGENT SHALL RESEARCH 10 TO 20 RESOURCE.
+EACH RESOURCE SHALL 'have RECORD url 'that EXISTS AND RECORD purpose 'that 'is SPECIFIC.
+AGENT SHALL CREATE DATA edge 'with RECORD weight 'for EACH RECORD relationship 'between RESOURCE.
+AGENT SHALL VALIDATE DATA graph web.trug.json.
+</trl>
+
+### Step by Step
+
+1. **Define branches** — who are the audiences? What pain point brings each audience to your project?
+2. **Research resources** — for each branch, find 10-20 high-quality resources: papers, repos, tools, articles, standards
+3. **Write purposes** — one sentence per resource explaining what it contains AND why it matters to your project
+4. **Create edges** — how do resources relate to each other and to your project? Weight by relevance
+5. **Validate** — run the validator to check graph correctness
+
+### Resource Categories
+
+<trl>
+DEFINE "PAPER" AS RECORD category — ACADEMIC RESEARCH OR TECHNICAL REPORT.
+DEFINE "REPO" AS RECORD category — GITHUB REPOSITORY OR CODE PROJECT.
+DEFINE "ARTICLE" AS RECORD category — BLOG POST OR TECHNICAL ARTICLE.
+DEFINE "TOOL" AS RECORD category — SOFTWARE TOOL OR GENERATOR.
+DEFINE "STANDARD" AS RECORD category — FORMAL STANDARD OR SPECIFICATION.
+DEFINE "GUIDE" AS RECORD category — HOWTO OR BEST PRACTICES.
+DEFINE "TEMPLATE" AS RECORD category — REUSABLE STARTING POINT.
+DEFINE "INFLUENCER" AS RECORD category — PERSON OR CHANNEL 'with RECORD audience.
+</trl>
+
+---
+
+## Updating a Web Hub
+
+<trl>
+IF AGENT DISCOVER RELEVANT RECORD web_resource THEN AGENT MAY ADD RESOURCE node.
+EACH NEW RESOURCE node SHALL CONTAIN RECORD url AND RECORD purpose AND RECORD category.
+AGENT SHALL CREATE DATA edge 'with RECORD weight TO EXISTING RESOURCE OR MODULE.
+AGENT SHALL_NOT ADD RESOURCE WITHOUT RECORD purpose — PURPOSE 'is REQUIRED.
+AGENT SHALL VALIDATE DATA graph AFTER EACH UPDATE.
+</trl>
+
+- **New resource found** — add a RESOURCE node with url, purpose, category. Create edges to related resources.
+- **Resource gone** — set `stale: true` on the node. Don't remove it — the edges still show the relationship.
+- **Better resource found** — add the new one, create an `SUPERSEDES` edge to the old one.
+
+---
+
+## Example
+
+See the main `web.trug.json` in this folder — 3 branches (Structured Agent, Graph Native, Agent Protocols), 54 nodes, 51 edges, 10 relation types. Also see `NDA/web.trug.json` for a domain-specific example (NDA research — templates, legal guidance, tools, WA state statutes).

--- a/installers/npm/templates/WEB_HUB/README.md
+++ b/installers/npm/templates/WEB_HUB/README.md
@@ -1,0 +1,27 @@
+# WEB_HUB — Curated Web Resource Graph
+
+A TRUG graph that indexes the web landscape around TRUGS-AGENT. Nodes are URLs — papers, repos, tools, articles, standards. Edges show how they relate. Weights rank importance.
+
+## Three Branches
+
+| Branch | Audience | Entry Point |
+|--------|----------|-------------|
+| **Structured Agent** | LLM developers frustrated with prompt drift | TRL + TRUGGING |
+| **Graph Native** | Engineers building with knowledge graphs and code graphs | FOLDER + TRUGGING |
+| **Agent Protocols** | Teams building reliable agent systems | AAA + MEMORY + EPIC |
+
+All three branches converge on TRUGS-AGENT — each audience discovers it through their own pain point.
+
+## How to Use
+
+Your LLM reads `web.trug.json` to navigate the landscape:
+- Find related work for a blog post
+- Pull citations for a paper
+- Answer "what's the state of the art in X?"
+- Identify gaps where TRUGS-AGENT is the only solution
+
+Edge weights (0.0–1.0) rank relevance to the TRUGS-AGENT story. Higher weight = stronger connection.
+
+## Structure
+
+`web.trug.json` contains three branch nodes, each containing 12-18 resource nodes. Resources link to each other and to TRUGS-AGENT components via weighted edges.

--- a/installers/npm/templates/WEB_HUB/web.trug.json
+++ b/installers/npm/templates/WEB_HUB/web.trug.json
@@ -1,0 +1,842 @@
+{
+  "name": "TRUGS-AGENT Web Hub",
+  "version": "1.0.0",
+  "type": "WEB_HUB",
+  "description": "Curated web resource graph — 3 branches, 50+ resources, weighted edges converging on TRUGS-AGENT",
+  "dimensions": {
+    "web_landscape": {
+      "description": "Web resources organized by audience and relevance to TRUGS-AGENT",
+      "base_level": "BASE"
+    }
+  },
+  "capabilities": {
+    "extensions": [],
+    "vocabularies": ["project_v1"],
+    "profiles": []
+  },
+  "nodes": [
+    {
+      "id": "hub_root",
+      "type": "FOLDER",
+      "properties": {
+        "name": "TRUGS-AGENT Web Hub",
+        "purpose": "Three-branch curated graph of web resources converging on TRUGS-AGENT adoption"
+      },
+      "parent_id": null,
+      "contains": ["branch_structured_agent", "branch_graph_native", "branch_agent_protocols", "convergence_trugs_agent", "convergence_trugs_spec", "convergence_trugs_paper", "convergence_natebjones", "convergence_natebjones_yt"],
+      "metric_level": "KILO_FOLDER",
+      "dimension": "web_landscape"
+    },
+
+    {
+      "id": "convergence_trugs_agent",
+      "type": "ENDPOINT",
+      "properties": {
+        "name": "TRUGS-AGENT Repository",
+        "url": "https://github.com/TRUGS-LLC/TRUGS-AGENT",
+        "purpose": "The product — one file teaches your LLM TRL, AAA, Memory, EPIC, Folder indexing, and Trugging",
+        "category": "REPO"
+      },
+      "parent_id": "hub_root",
+      "contains": [],
+      "metric_level": "HECTO_ENDPOINT",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "convergence_trugs_spec",
+      "type": "ENDPOINT",
+      "properties": {
+        "name": "TRUGS Specification Repository",
+        "url": "https://github.com/TRUGS-LLC/TRUGS",
+        "purpose": "Full TRL + TRUGS specification — 190-word vocabulary, CORE rules, validator, the complete formal system",
+        "category": "REPO"
+      },
+      "parent_id": "hub_root",
+      "contains": [],
+      "metric_level": "HECTO_ENDPOINT",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "convergence_trugs_paper",
+      "type": "ENDPOINT",
+      "properties": {
+        "name": "TRUGS Paper (Zenodo DOI)",
+        "url": "https://doi.org/10.5281/zenodo.19379454",
+        "purpose": "Academic paper — TRUGS specification, TRL compilation algorithm, graph-sentence equivalence proof",
+        "category": "PAPER"
+      },
+      "parent_id": "hub_root",
+      "contains": [],
+      "metric_level": "HECTO_ENDPOINT",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "convergence_natebjones",
+      "type": "ENDPOINT",
+      "properties": {
+        "name": "Nate B Jones",
+        "url": "https://natebjones.com",
+        "purpose": "Tech creator with 500K+ audience — potential TRUGS-AGENT evangelist and adoption channel",
+        "category": "INFLUENCER"
+      },
+      "parent_id": "hub_root",
+      "contains": [],
+      "metric_level": "HECTO_ENDPOINT",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "convergence_natebjones_yt",
+      "type": "ENDPOINT",
+      "properties": {
+        "name": "Nate B Jones — YouTube",
+        "url": "https://www.youtube.com/@NateBJones",
+        "purpose": "YouTube channel — AI/dev tooling content reaching 500K+ audience, video format for TRUGS-AGENT demos",
+        "category": "INFLUENCER"
+      },
+      "parent_id": "hub_root",
+      "contains": [],
+      "metric_level": "HECTO_ENDPOINT",
+      "dimension": "web_landscape"
+    },
+
+    {
+      "id": "branch_structured_agent",
+      "type": "MODULE",
+      "properties": {
+        "name": "Structured Agent Instructions",
+        "purpose": "Branch 1 — the problem of prompt ambiguity and solutions for formalized LLM instructions",
+        "audience": "LLM developers frustrated with prompt drift",
+        "converges_on": "TRL + TRUGGING"
+      },
+      "parent_id": "hub_root",
+      "contains": ["sa_specs_paper", "sa_prompt_report", "sa_ifeval", "sa_goal_drift", "sa_lmql_paper", "sa_agentif", "sa_dspy", "sa_guidance", "sa_lmql", "sa_typechat", "sa_outlines", "sa_instructor", "sa_json_prompting", "sa_anthropic_prompting", "sa_llmops_2025"],
+      "metric_level": "HECTO_MODULE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_specs_paper",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Specifications: The Missing Link to Making LLM Systems an Engineering Discipline",
+        "url": "https://arxiv.org/abs/2412.05299",
+        "purpose": "UC Berkeley paper arguing that precise specification of expected behavior is the missing foundation for reliable LLM systems — the exact problem TRL solves",
+        "category": "PAPER",
+        "authors": "Ion Stoica, Matei Zaharia et al."
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_prompt_report",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "The Prompt Report: A Systematic Survey of Prompting Techniques",
+        "url": "https://arxiv.org/abs/2406.06608",
+        "purpose": "76-page survey covering 58 text prompting techniques from 1,500+ papers — the landscape TRL simplifies to 190 words",
+        "category": "PAPER",
+        "authors": "Schulhoff et al. (OpenAI, Microsoft, Google, Stanford)"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_ifeval",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "IFEval: Instruction-Following Evaluation for Large Language Models",
+        "url": "https://arxiv.org/abs/2311.07911",
+        "purpose": "Google Research benchmark with 25 verifiable instruction types and ~500 test prompts measuring LLM compliance with precise constraints",
+        "category": "PAPER",
+        "authors": "Jeffrey Zhou et al."
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_goal_drift",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Evaluating Goal Drift in Language Model Agents",
+        "url": "https://arxiv.org/html/2505.02709v1",
+        "purpose": "Quantifies how LLM agents progressively deviate from original instructions during long-context interactions — the drift TRL prevents",
+        "category": "PAPER"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_lmql_paper",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Prompting Is Programming: A Query Language for Large Language Models",
+        "url": "https://arxiv.org/abs/2212.06094",
+        "purpose": "ETH Zurich paper proposing prompting-as-programming with constraints and types — TRL takes this further with a fixed vocabulary that compiles to graphs",
+        "category": "PAPER",
+        "authors": "Beurer-Kellner et al."
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_agentif",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "AGENTIF: Benchmarking Instruction Following of LLMs as Agents",
+        "url": "https://keg.cs.tsinghua.edu.cn/persons/xubin/papers/AgentIF.pdf",
+        "purpose": "Tsinghua benchmark finding even GPT-4 achieves only ~80% on simple unambiguous instructions — motivates formalized instruction languages",
+        "category": "PAPER"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_dspy",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "DSPy — Programming, Not Prompting, Language Models",
+        "url": "https://github.com/stanfordnlp/dspy",
+        "purpose": "Stanford framework replacing brittle prompts with composable Python modules — structured generation without a fixed vocabulary",
+        "category": "TOOL"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_guidance",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Guidance — Token-Level LLM Output Control",
+        "url": "https://github.com/guidance-ai/guidance",
+        "purpose": "Controls LLM output via Python-embedded grammars and CFGs — structural constraints at inference layer, not post-hoc",
+        "category": "TOOL"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_lmql",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "LMQL — Query Language for LLMs",
+        "url": "https://github.com/eth-sri/lmql",
+        "purpose": "SQL-like declarative constraints for LLMs — typed output specifications and multi-variable templates",
+        "category": "TOOL"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_typechat",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "TypeChat — Schema Engineering for LLMs",
+        "url": "https://github.com/microsoft/TypeChat",
+        "purpose": "Microsoft tool replacing prompt engineering with TypeScript schema engineering — validates responses against types",
+        "category": "TOOL"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_outlines",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Outlines — Structured Generation via FSMs",
+        "url": "https://github.com/dottxt-ai/outlines",
+        "purpose": "Compiles JSON schemas and regex into finite state machines for guaranteed-valid LLM output during token generation",
+        "category": "TOOL"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_instructor",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Instructor — Pydantic-Based Structured LLM Output",
+        "url": "https://github.com/567-labs/instructor",
+        "purpose": "Pydantic validation for LLM responses with automatic retries — available in Python, TypeScript, Go, Ruby, Rust, Elixir",
+        "category": "TOOL"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_json_prompting",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Structured Prompting with JSON: The Engineering Path to Reliable LLMs",
+        "url": "https://medium.com/@vishal.dutt.data.architect/structured-prompting-with-json-the-engineering-path-to-reliable-llms-2c0cb1b767cf",
+        "purpose": "Introduces the 'Ambiguity Tax' concept — operational cost of vague prompts, reports 99%+ schema adherence with structured JSON prompting",
+        "category": "ARTICLE"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_anthropic_prompting",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Anthropic — Claude Prompting Best Practices",
+        "url": "https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices",
+        "purpose": "Official Anthropic guide recommending XML-tagged structure, role-based system prompts, and schema-first design",
+        "category": "ARTICLE"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_llmops_2025",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "What 1,200 Production Deployments Reveal About LLMOps in 2025",
+        "url": "https://www.zenml.io/blog/what-1200-production-deployments-reveal-about-llmops-in-2025",
+        "purpose": "Production retrospective marking the shift from prompt engineering to context engineering — architecting structured information, not tweaking wording",
+        "category": "ARTICLE"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+
+    {
+      "id": "branch_graph_native",
+      "type": "MODULE",
+      "properties": {
+        "name": "Graph-Native Development",
+        "purpose": "Branch 2 — using graphs to describe, index, and navigate codebases and knowledge",
+        "audience": "Engineers building with knowledge graphs and code graphs",
+        "converges_on": "FOLDER + TRUGGING"
+      },
+      "parent_id": "hub_root",
+      "contains": ["gn_kg_survey", "gn_kg_evolution", "gn_llm_kg_construction", "gn_neo4j", "gn_networkx", "gn_joern", "gn_treesitter_graph", "gn_emerge", "gn_code_property_graph", "gn_neo4j_codebase", "gn_dependency_graphs", "gn_software_dep_graph", "gn_graph4code", "gn_jsonld", "gn_gql"],
+      "metric_level": "HECTO_MODULE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_kg_survey",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Knowledge Graphs: Opportunities and Challenges",
+        "url": "https://link.springer.com/article/10.1007/s10462-023-10465-9",
+        "purpose": "Comprehensive survey covering KG construction, embedding, reasoning, and applications — the academic foundation for graph-based systems",
+        "category": "PAPER"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_kg_evolution",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "On the Evolution of Knowledge Graphs: A Survey and Perspective",
+        "url": "https://arxiv.org/abs/2310.04835",
+        "purpose": "Covers static, dynamic, temporal, and event knowledge graphs with extraction and reasoning techniques",
+        "category": "PAPER"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_llm_kg_construction",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "LLM-Empowered Knowledge Graph Construction: A Survey",
+        "url": "https://arxiv.org/abs/2510.20345",
+        "purpose": "How LLMs reshape the KG construction pipeline from ontology engineering through knowledge fusion — TRUGS automates this for codebases",
+        "category": "PAPER"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_neo4j",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Neo4j — Graph Database",
+        "url": "https://github.com/neo4j/neo4j",
+        "purpose": "Leading open-source property graph database with ACID transactions and Cypher query language — the heavyweight; TRUGS is the lightweight JSON alternative",
+        "category": "REPO"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_networkx",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "NetworkX — Network Analysis in Python",
+        "url": "https://github.com/networkx/networkx",
+        "purpose": "Python library for graph creation, manipulation, and analysis — computation engine, not a specification format",
+        "category": "REPO"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_joern",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Joern — Code Analysis via Code Property Graphs",
+        "url": "https://github.com/joernio/joern",
+        "purpose": "Code analysis platform for C/C++/Java/Python/JS based on code property graphs — analyzes code as graphs, TRUGS indexes projects as graphs",
+        "category": "REPO"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_treesitter_graph",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "tree-sitter-graph — DSL for Graph Construction from Source Code",
+        "url": "https://github.com/tree-sitter/tree-sitter-graph",
+        "purpose": "Rust DSL for constructing arbitrary graph structures from parsed source code — AST to graph, bottom-up",
+        "category": "REPO"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_emerge",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Emerge — Interactive Codebase Visualization",
+        "url": "https://github.com/glato/emerge",
+        "purpose": "Browser-based dependency visualization with graph metrics — visual where TRUGS is structural",
+        "category": "REPO"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_code_property_graph",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Code Property Graph — Specification and Query Language",
+        "url": "https://github.com/ShiftLeftSecurity/codepropertygraph",
+        "purpose": "Formal spec of the code property graph data structure — security-focused code graph, TRUGS is project-focused",
+        "category": "REPO"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_neo4j_codebase",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Codebase Knowledge Graph: Code Analysis with Graphs",
+        "url": "https://neo4j.com/blog/developer/codebase-knowledge-graph/",
+        "purpose": "Neo4j blog demonstrating Cypher queries for structural code analysis — heavy tooling, TRUGS does it with one JSON file",
+        "category": "ARTICLE"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_dependency_graphs",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Safely Restructure Your Codebase with Dependency Graphs",
+        "url": "https://understandlegacycode.com/blog/safely-restructure-codebase-with-dependency-graphs/",
+        "purpose": "Practical guide to using dependency graphs for safe refactoring of legacy codebases",
+        "category": "ARTICLE"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_software_dep_graph",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Software Dependency Graphs: Definition, Use Cases, and Implementation",
+        "url": "https://www.puppygraph.com/blog/software-dependency-graph",
+        "purpose": "Overview of how dependency graphs represent file/class/function/library relationships in codebases",
+        "category": "ARTICLE"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_graph4code",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "GraphGen4Code — Code Knowledge Graph Toolkit",
+        "url": "https://wala.github.io/graph4code/",
+        "purpose": "IBM toolkit for building code knowledge graphs powering program search, code understanding, and bug detection",
+        "category": "TOOL"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_jsonld",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "JSON-LD 1.1 — W3C Recommendation",
+        "url": "https://www.w3.org/TR/json-ld11/",
+        "purpose": "W3C standard for encoding linked/graph data in JSON — bridges JSON simplicity with RDF expressiveness. TRUGS is simpler: no @context, no namespaces",
+        "category": "STANDARD"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_gql",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "GQL — Graph Query Language (ISO/IEC 39075:2024)",
+        "url": "https://www.gqlstandards.org/",
+        "purpose": "First new ISO database query language in 35+ years — complete DML/DDL for property graphs. TRUGS is a format, not a query language",
+        "category": "STANDARD"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+
+    {
+      "id": "branch_agent_protocols",
+      "type": "MODULE",
+      "properties": {
+        "name": "LLM Agent Protocols",
+        "purpose": "Branch 3 — development workflows, memory systems, and reliability patterns for LLM-powered agents",
+        "audience": "Teams building reliable agent systems",
+        "converges_on": "AAA + MEMORY + EPIC"
+      },
+      "parent_id": "hub_root",
+      "contains": ["ap_planning_survey", "ap_memory_survey", "ap_agentic_reasoning", "ap_autonomous_agents", "ap_anthropic_auditing", "ap_langgraph", "ap_crewai", "ap_autogen", "ap_openhands", "ap_claude_code_action", "ap_building_agents", "ap_claude_agent_sdk", "ap_year_in_llms", "ap_promptfoo", "ap_awesome_memory"],
+      "metric_level": "HECTO_MODULE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_planning_survey",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Understanding the Planning of LLM Agents: A Survey",
+        "url": "https://arxiv.org/abs/2402.02716",
+        "purpose": "Survey of planning in LLM agents — task decomposition, multi-step reasoning, replanning. AAA is a fixed 9-phase plan that removes the need for ad-hoc planning",
+        "category": "PAPER"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_memory_survey",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Memory for Autonomous LLM Agents: Mechanisms, Evaluation, and Frontiers",
+        "url": "https://arxiv.org/html/2603.07670",
+        "purpose": "Survey of agent memory architectures — episodic, semantic, procedural. TRUGS Memory is simpler: 4 types, markdown files, MEMORY.md index",
+        "category": "PAPER"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_agentic_reasoning",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Agentic Reasoning for Large Language Models",
+        "url": "https://arxiv.org/abs/2601.12538",
+        "purpose": "Unified roadmap bridging thought and action in LLM agents — personalization, long-horizon interaction, multi-agent scaling",
+        "category": "PAPER"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_autonomous_agents",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "From LLM Reasoning to Autonomous AI Agents: A Comprehensive Review",
+        "url": "https://arxiv.org/abs/2504.19678",
+        "purpose": "Reviews 2023-2025 agent frameworks integrating LLMs with modular toolkits for autonomous decision-making",
+        "category": "PAPER"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_anthropic_auditing",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Building and Evaluating Alignment Auditing Agents",
+        "url": "https://alignment.anthropic.com/2025/automated-auditing/",
+        "purpose": "Anthropic research on automated agent auditing — the problem AAA Phase 8 solves with spec-defined audit criteria",
+        "category": "PAPER"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_langgraph",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "LangGraph — Build Resilient Language Agents as Graphs",
+        "url": "https://github.com/langchain-ai/langgraph",
+        "purpose": "Stateful multi-step agent workflows as directed graphs with persistence — graph-based execution, not graph-based specification",
+        "category": "REPO"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_crewai",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "CrewAI — Orchestrating Role-Playing Autonomous AI Agents",
+        "url": "https://github.com/crewaiinc/crewai",
+        "purpose": "Multi-agent framework with role-based crews and structured flows — orchestration without formalized instructions",
+        "category": "REPO"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_autogen",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Microsoft AutoGen — Agentic AI Framework",
+        "url": "https://github.com/microsoft/autogen",
+        "purpose": "Multi-agent conversation framework enabling LLM/tool/human integration — agent chat without development protocol",
+        "category": "REPO"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_openhands",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "OpenHands — AI-Driven Software Development Platform",
+        "url": "https://github.com/OpenHands/OpenHands",
+        "purpose": "Open-source coding agent with composable SDK and GitHub issue resolver — execution without plan-before-code protocol",
+        "category": "REPO"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_claude_code_action",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Claude Code Action — GitHub Actions Integration",
+        "url": "https://github.com/anthropics/claude-code-action",
+        "purpose": "Official Anthropic action for Claude Code in CI/CD — autonomous agent in pipelines, uses CLAUDE.md for instructions",
+        "category": "REPO"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_building_agents",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Building Effective Agents",
+        "url": "https://www.anthropic.com/research/building-effective-agents",
+        "purpose": "Anthropic's foundational guide — human-in-the-loop checkpoints, stopping conditions, agents as LLMs in loops with tools. AAA formalizes this into 9 phases.",
+        "category": "ARTICLE"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_claude_agent_sdk",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Building Agents with the Claude Agent SDK",
+        "url": "https://www.anthropic.com/engineering/building-agents-with-the-claude-agent-sdk",
+        "purpose": "Engineering guide on self-evaluating agents that check and improve their own output — three approaches to agent reliability",
+        "category": "ARTICLE"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_year_in_llms",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "2025: The Year in LLMs — Simon Willison",
+        "url": "https://simonwillison.net/2025/Dec/31/the-year-in-llms/",
+        "purpose": "Year-end review covering rise of coding agents (Claude Code, Copilot CLI, OpenHands), IDE integration, autonomous development workflows",
+        "category": "ARTICLE"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_promptfoo",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Promptfoo — CI/CD for LLM Evaluation",
+        "url": "https://www.promptfoo.dev/docs/integrations/ci-cd/",
+        "purpose": "LLM evaluation in CI/CD pipelines with quality gates and automated red-teaming — testing without formalized specs",
+        "category": "TOOL"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_awesome_memory",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Awesome Memory for Agents — Tsinghua C3I",
+        "url": "https://github.com/TsinghuaC3I/Awesome-Memory-for-Agents",
+        "purpose": "Curated paper collection on agent memory — episodic, semantic, procedural memory mechanisms and persistence strategies",
+        "category": "REPO"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    }
+  ],
+  "edges": [
+    {"from_id": "branch_structured_agent", "to_id": "convergence_trugs_agent", "relation": "FEEDS", "weight": 1.0, "properties": {"path": "Prompt ambiguity → TRL solves it → TRUGS-AGENT delivers it"}},
+    {"from_id": "branch_graph_native", "to_id": "convergence_trugs_agent", "relation": "FEEDS", "weight": 1.0, "properties": {"path": "Graph tooling → FOLDER indexes it → TRUGS-AGENT delivers it"}},
+    {"from_id": "branch_agent_protocols", "to_id": "convergence_trugs_agent", "relation": "FEEDS", "weight": 1.0, "properties": {"path": "Agent reliability → AAA/Memory/EPIC solve it → TRUGS-AGENT delivers it"}},
+
+    {"from_id": "convergence_trugs_agent", "to_id": "convergence_trugs_spec", "relation": "IMPLEMENTS", "weight": 1.0, "properties": {}},
+    {"from_id": "convergence_trugs_spec", "to_id": "convergence_trugs_paper", "relation": "DESCRIBES", "weight": 0.9, "properties": {}},
+
+    {"from_id": "convergence_natebjones", "to_id": "convergence_trugs_agent", "relation": "AMPLIFIES", "weight": 0.9, "properties": {"channel": "Website — tech content, 500K+ audience"}},
+    {"from_id": "convergence_natebjones_yt", "to_id": "convergence_trugs_agent", "relation": "AMPLIFIES", "weight": 0.9, "properties": {"channel": "YouTube — video demos, broader reach"}},
+    {"from_id": "convergence_natebjones_yt", "to_id": "convergence_natebjones", "relation": "EXTENDS", "weight": 0.8, "properties": {"relationship": "Same creator, video format"}},
+
+    {"from_id": "sa_specs_paper", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.95, "properties": {"connection": "Paper argues specifications are missing — TRL is that specification"}},
+    {"from_id": "sa_goal_drift", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.9, "properties": {"connection": "Drift is the problem — fixed vocabulary prevents it"}},
+    {"from_id": "sa_ifeval", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.8, "properties": {"connection": "Instruction following benchmarks — TRL makes instructions unambiguous"}},
+    {"from_id": "sa_agentif", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.8, "properties": {"connection": "80% compliance on simple instructions — TRL pushes toward 100%"}},
+    {"from_id": "sa_prompt_report", "to_id": "convergence_trugs_agent", "relation": "CONTEXTUALIZES", "weight": 0.7, "properties": {"connection": "58 prompting techniques — TRL replaces all of them with one language"}},
+    {"from_id": "sa_lmql_paper", "to_id": "convergence_trugs_agent", "relation": "CONTEXTUALIZES", "weight": 0.7, "properties": {"connection": "Prompting as programming — TRL takes it further with graph compilation"}},
+
+    {"from_id": "sa_dspy", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.7, "properties": {"difference": "DSPy optimizes prompts automatically — TRL eliminates ambiguity by design"}},
+    {"from_id": "sa_guidance", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.6, "properties": {"difference": "Guidance constrains output tokens — TRL constrains input instructions"}},
+    {"from_id": "sa_typechat", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.6, "properties": {"difference": "TypeChat validates output against schema — TRL validates instructions against vocabulary"}},
+    {"from_id": "sa_outlines", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.5, "properties": {"difference": "Outlines ensures valid output format — TRL ensures valid input specification"}},
+    {"from_id": "sa_instructor", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.5, "properties": {"difference": "Instructor validates responses — TRL validates instructions"}},
+    {"from_id": "sa_lmql", "to_id": "sa_lmql_paper", "relation": "IMPLEMENTS", "weight": 0.9, "properties": {}},
+    {"from_id": "sa_anthropic_prompting", "to_id": "convergence_trugs_agent", "relation": "CONTEXTUALIZES", "weight": 0.6, "properties": {"connection": "Recommends structured prompts — TRL is the most structured prompt"}},
+    {"from_id": "sa_llmops_2025", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.7, "properties": {"connection": "Shift from prompt engineering to context engineering — TRL is the context engineering language"}},
+    {"from_id": "sa_json_prompting", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.6, "properties": {"connection": "Ambiguity Tax concept — TRL eliminates the tax"}},
+
+    {"from_id": "gn_neo4j", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.7, "properties": {"difference": "Neo4j is a database — TRUGS is a specification format. Neo4j requires a server; TRUGS is one JSON file"}},
+    {"from_id": "gn_joern", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.7, "properties": {"difference": "Joern analyzes code as graphs — TRUGS indexes projects as graphs. Different granularity"}},
+    {"from_id": "gn_code_property_graph", "to_id": "gn_joern", "relation": "GOVERNS", "weight": 0.9, "properties": {"relationship": "CPG spec underlies Joern"}},
+    {"from_id": "gn_treesitter_graph", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.6, "properties": {"difference": "tree-sitter-graph builds graphs from ASTs — TRUGS builds graphs from project structure"}},
+    {"from_id": "gn_emerge", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.5, "properties": {"difference": "Emerge visualizes — TRUGS specifies. Different output: visual vs machine-readable"}},
+    {"from_id": "gn_graph4code", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.6, "properties": {"difference": "Graph4Code builds code KGs for search — TRUGS builds project KGs for navigation"}},
+    {"from_id": "gn_jsonld", "to_id": "convergence_trugs_spec", "relation": "CONTRASTS", "weight": 0.7, "properties": {"difference": "JSON-LD links to the semantic web — TRUGS links to nothing external. Simpler: no @context, no namespaces"}},
+    {"from_id": "gn_gql", "to_id": "convergence_trugs_spec", "relation": "CONTRASTS", "weight": 0.6, "properties": {"difference": "GQL queries graphs — TRL describes graphs as sentences. Query language vs specification language"}},
+    {"from_id": "gn_kg_survey", "to_id": "gn_kg_evolution", "relation": "EXTENDS", "weight": 0.8, "properties": {}},
+    {"from_id": "gn_llm_kg_construction", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.8, "properties": {"connection": "LLMs building KGs — TRUGS is the format they build into"}},
+    {"from_id": "gn_neo4j_codebase", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.7, "properties": {"connection": "Shows codebase-as-graph value — TRUGS does it without Neo4j"}},
+    {"from_id": "gn_dependency_graphs", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.6, "properties": {"connection": "Dependency graphs for refactoring — folder.trug.json is the persistent index"}},
+    {"from_id": "gn_networkx", "to_id": "convergence_trugs_spec", "relation": "COMPLEMENTS", "weight": 0.5, "properties": {"relationship": "NetworkX can load and analyze TRUGS graphs"}},
+
+    {"from_id": "ap_building_agents", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.95, "properties": {"connection": "Anthropic's agent patterns — AAA formalizes them into 9 mandatory phases"}},
+    {"from_id": "ap_anthropic_auditing", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.9, "properties": {"connection": "Agent auditing research — AAA Phase 3 defines criteria, Phase 8 executes audit"}},
+    {"from_id": "ap_planning_survey", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.85, "properties": {"connection": "Ad-hoc planning survey — AAA replaces ad-hoc with fixed 9-phase protocol"}},
+    {"from_id": "ap_memory_survey", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.85, "properties": {"connection": "Complex memory architectures — TRUGS Memory is 4 types in markdown files"}},
+    {"from_id": "ap_claude_agent_sdk", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.8, "properties": {"connection": "Self-evaluating agents — AAA audit cycle is the formalized version"}},
+
+    {"from_id": "ap_langgraph", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.8, "properties": {"difference": "LangGraph executes workflows as graphs — TRUGS specifies projects as graphs. Runtime vs specification"}},
+    {"from_id": "ap_crewai", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.7, "properties": {"difference": "CrewAI orchestrates multiple agents — TRUGS-AGENT teaches one agent to work correctly"}},
+    {"from_id": "ap_autogen", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.7, "properties": {"difference": "AutoGen enables agent chat — TRUGS-AGENT enables agent discipline"}},
+    {"from_id": "ap_openhands", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.7, "properties": {"difference": "OpenHands is a coding platform — TRUGS-AGENT is a methodology that works in any platform"}},
+    {"from_id": "ap_claude_code_action", "to_id": "convergence_trugs_agent", "relation": "COMPLEMENTS", "weight": 0.85, "properties": {"relationship": "Claude Code reads CLAUDE.md — TRUGS-AGENT IS the CLAUDE.md"}},
+
+    {"from_id": "ap_year_in_llms", "to_id": "convergence_trugs_agent", "relation": "CONTEXTUALIZES", "weight": 0.6, "properties": {"connection": "Landscape overview — shows the ecosystem TRUGS-AGENT operates in"}},
+    {"from_id": "ap_promptfoo", "to_id": "convergence_trugs_agent", "relation": "COMPLEMENTS", "weight": 0.6, "properties": {"relationship": "Promptfoo tests LLM output — TRL makes the input testable too"}},
+    {"from_id": "ap_awesome_memory", "to_id": "ap_memory_survey", "relation": "EXTENDS", "weight": 0.8, "properties": {}},
+    {"from_id": "ap_agentic_reasoning", "to_id": "ap_planning_survey", "relation": "EXTENDS", "weight": 0.7, "properties": {}},
+    {"from_id": "ap_autonomous_agents", "to_id": "convergence_trugs_agent", "relation": "CONTEXTUALIZES", "weight": 0.6, "properties": {"connection": "Reviews 2023-2025 agent frameworks — TRUGS-AGENT is the 2026 answer"}}
+  ]
+}

--- a/installers/npm/templates/tools/__init__.py
+++ b/installers/npm/templates/tools/__init__.py
@@ -1,0 +1,1 @@
+"""TRUGS CLI tools — create, read, update, delete operations on TRUG graphs."""

--- a/installers/npm/templates/tools/test_validate.py
+++ b/installers/npm/templates/tools/test_validate.py
@@ -1,0 +1,541 @@
+"""Tests for TRUGS validator — all 16 CORE rules."""
+
+import json
+import tempfile
+from pathlib import Path
+from copy import deepcopy
+
+from validate import (
+    validate, validate_file, ValidationResult,
+    rule_1_unique_ids, rule_2_edge_id_validity, rule_3_hierarchy_consistency,
+    rule_4_metric_level_ordering, rule_5_dimension_declaration,
+    rule_6_required_fields, rule_7_field_type_correctness,
+    rule_8_extension_declaration, rule_9_metric_level_format,
+    rule_10_subject_operation, rule_11_operation_object,
+    rule_12_modifier_entity, rule_13_qualifier_operation,
+    rule_14_constraint_subject, rule_15_no_double_negation,
+    rule_16_reference_scope,
+)
+
+
+# ─── Fixtures ──────────────────────────────────────────────────────────────────
+
+MINIMAL_VALID = {
+    "name": "Test",
+    "version": "1.0.0",
+    "type": "CODE",
+    "dimensions": {"d": {"description": "test", "base_level": "BASE"}},
+    "capabilities": {"extensions": [], "vocabularies": [], "profiles": []},
+    "nodes": [
+        {
+            "id": "root",
+            "type": "MODULE",
+            "properties": {},
+            "parent_id": None,
+            "contains": [],
+            "metric_level": "DEKA_MODULE",
+            "dimension": "d",
+        }
+    ],
+    "edges": [],
+}
+
+MINIMAL_V091 = {
+    "name": "Test v1.0.0",
+    "version": "1.0.0",
+    "type": "CODE",
+    "dimensions": {"d": {"description": "test"}},
+    "capabilities": {"extensions": [], "vocabularies": ["core_v1.0.0"], "profiles": []},
+    "nodes": [
+        {
+            "id": "system",
+            "type": "PARTY",
+            "properties": {},
+            "parent_id": None,
+            "contains": [],
+            "metric_level": "BASE_ACTOR",
+            "dimension": "d",
+        }
+    ],
+    "edges": [],
+}
+
+
+def _make(**overrides):
+    t = deepcopy(MINIMAL_VALID)
+    t.update(overrides)
+    return t
+
+
+def _make_v091(**overrides):
+    t = deepcopy(MINIMAL_V091)
+    t.update(overrides)
+    return t
+
+
+def _run(trug):
+    return validate(trug)
+
+
+def _errors(result):
+    return [e.code for e in result.errors]
+
+
+# ─── Rule 1: Unique IDs ───────────────────────────────────────────────────────
+
+def test_rule_1_pass():
+    r = _run(MINIMAL_VALID)
+    assert "DUPLICATE_NODE_ID" not in _errors(r)
+
+
+def test_rule_1_duplicate():
+    t = _make(nodes=[
+        {"id": "a", "type": "X", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_X", "dimension": "d"},
+        {"id": "a", "type": "Y", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_Y", "dimension": "d"},
+    ])
+    r = _run(t)
+    assert "DUPLICATE_NODE_ID" in _errors(r)
+
+
+def test_rule_1_missing_id():
+    t = _make(nodes=[
+        {"type": "X", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_X", "dimension": "d"},
+    ])
+    r = _run(t)
+    assert "MISSING_NODE_ID" in _errors(r)
+
+
+# ─── Rule 2: Edge ID Validity ─────────────────────────────────────────────────
+
+def test_rule_2_pass():
+    t = _make(
+        nodes=[
+            {"id": "a", "type": "X", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_X", "dimension": "d"},
+            {"id": "b", "type": "Y", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_Y", "dimension": "d"},
+        ],
+        edges=[{"from_id": "a", "to_id": "b", "relation": "CALLS"}],
+    )
+    r = _run(t)
+    assert "INVALID_EDGE_REFERENCE" not in _errors(r)
+
+
+def test_rule_2_invalid_from():
+    t = _make(edges=[{"from_id": "ghost", "to_id": "root", "relation": "X"}])
+    r = _run(t)
+    assert "INVALID_EDGE_REFERENCE" in _errors(r)
+
+
+def test_rule_2_cross_folder_ref_allowed():
+    t = _make(edges=[{"from_id": "root", "to_id": "other_folder:node_1", "relation": "X"}])
+    r = _run(t)
+    assert "INVALID_EDGE_REFERENCE" not in _errors(r)
+
+
+# ─── Rule 3: Hierarchy Consistency ─────────────────────────────────────────────
+
+def test_rule_3_pass():
+    t = _make(nodes=[
+        {"id": "parent", "type": "X", "properties": {}, "parent_id": None, "contains": ["child"], "metric_level": "DEKA_X", "dimension": "d"},
+        {"id": "child", "type": "Y", "properties": {}, "parent_id": "parent", "contains": [], "metric_level": "BASE_Y", "dimension": "d"},
+    ])
+    r = _run(t)
+    assert "INCONSISTENT_HIERARCHY" not in _errors(r)
+
+
+def test_rule_3_parent_missing_child():
+    t = _make(nodes=[
+        {"id": "parent", "type": "X", "properties": {}, "parent_id": None, "contains": [], "metric_level": "DEKA_X", "dimension": "d"},
+        {"id": "child", "type": "Y", "properties": {}, "parent_id": "parent", "contains": [], "metric_level": "BASE_Y", "dimension": "d"},
+    ])
+    r = _run(t)
+    assert "INCONSISTENT_HIERARCHY" in _errors(r)
+
+
+def test_rule_3_contains_missing_parent():
+    t = _make(nodes=[
+        {"id": "parent", "type": "X", "properties": {}, "parent_id": None, "contains": ["child"], "metric_level": "DEKA_X", "dimension": "d"},
+        {"id": "child", "type": "Y", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_Y", "dimension": "d"},
+    ])
+    r = _run(t)
+    assert "INCONSISTENT_HIERARCHY" in _errors(r)
+
+
+# ─── Rule 4: Metric Level Ordering ────────────────────────────────────────────
+
+def test_rule_4_pass():
+    t = _make(nodes=[
+        {"id": "p", "type": "X", "properties": {}, "parent_id": None, "contains": ["c"], "metric_level": "DEKA_X", "dimension": "d"},
+        {"id": "c", "type": "Y", "properties": {}, "parent_id": "p", "contains": [], "metric_level": "BASE_Y", "dimension": "d"},
+    ])
+    r = _run(t)
+    assert "INVALID_METRIC_ORDERING" not in _errors(r)
+
+
+def test_rule_4_child_bigger_than_parent():
+    t = _make(nodes=[
+        {"id": "p", "type": "X", "properties": {}, "parent_id": None, "contains": ["c"], "metric_level": "BASE_X", "dimension": "d"},
+        {"id": "c", "type": "Y", "properties": {}, "parent_id": "p", "contains": [], "metric_level": "KILO_Y", "dimension": "d"},
+    ])
+    r = _run(t)
+    assert "INVALID_METRIC_ORDERING" in _errors(r)
+
+
+# ─── Rule 5: Dimension Declaration ────────────────────────────────────────────
+
+def test_rule_5_pass():
+    r = _run(MINIMAL_VALID)
+    assert "UNDECLARED_DIMENSION" not in _errors(r)
+
+
+def test_rule_5_undeclared():
+    t = _make(nodes=[
+        {"id": "x", "type": "X", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_X", "dimension": "nonexistent"},
+    ])
+    r = _run(t)
+    assert "UNDECLARED_DIMENSION" in _errors(r)
+
+
+# ─── Rule 6: Required Fields ──────────────────────────────────────────────────
+
+def test_rule_6_pass():
+    r = _run(MINIMAL_VALID)
+    assert "MISSING_REQUIRED_FIELD" not in _errors(r)
+
+
+def test_rule_6_missing_root_field():
+    t = {"version": "1.0.0", "type": "X", "nodes": [], "edges": []}  # missing 'name'
+    r = _run(t)
+    assert "MISSING_REQUIRED_FIELD" in _errors(r)
+
+
+def test_rule_6_missing_node_field():
+    t = _make(nodes=[{"id": "x", "type": "X"}])  # missing properties, parent_id, contains, metric_level
+    r = _run(t)
+    codes = _errors(r)
+    assert codes.count("MISSING_REQUIRED_FIELD") >= 3
+
+
+# ─── Rule 7: Field Type Correctness ───────────────────────────────────────────
+
+def test_rule_7_pass():
+    r = _run(MINIMAL_VALID)
+    assert "INVALID_FIELD_TYPE" not in _errors(r)
+
+
+def test_rule_7_id_not_string():
+    t = _make(nodes=[
+        {"id": 123, "type": "X", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_X", "dimension": "d"},
+    ])
+    r = _run(t)
+    assert "INVALID_FIELD_TYPE" in _errors(r)
+
+
+def test_rule_7_weight_out_of_range():
+    t = _make(edges=[{"from_id": "root", "to_id": "root", "relation": "X", "weight": 1.5}])
+    r = _run(t)
+    assert "INVALID_EDGE_WEIGHT" in _errors(r)
+
+
+def test_rule_7_weight_boolean():
+    t = _make(edges=[{"from_id": "root", "to_id": "root", "relation": "X", "weight": True}])
+    r = _run(t)
+    assert "INVALID_EDGE_WEIGHT" in _errors(r)
+
+
+# ─── Rule 8: Extension Declaration ────────────────────────────────────────────
+
+def test_rule_8_pass():
+    r = _run(MINIMAL_VALID)
+    assert "UNDECLARED_EXTENSION" not in _errors(r)
+
+
+def test_rule_8_undeclared_typed():
+    t = _make(nodes=[
+        {"id": "x", "type": "X", "properties": {"type_info": {"category": "func"}}, "parent_id": None, "contains": [], "metric_level": "BASE_X", "dimension": "d"},
+    ])
+    r = _run(t)
+    assert "UNDECLARED_EXTENSION" in _errors(r)
+
+
+# ─── Rule 9: Metric Level Format ──────────────────────────────────────────────
+
+def test_rule_9_pass():
+    r = _run(MINIMAL_VALID)
+    assert "INVALID_METRIC_FORMAT" not in _errors(r)
+
+
+def test_rule_9_no_underscore():
+    t = _make(nodes=[
+        {"id": "x", "type": "X", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASEMODULE", "dimension": "d"},
+    ])
+    r = _run(t)
+    assert "INVALID_METRIC_FORMAT" in _errors(r)
+
+
+def test_rule_9_invalid_prefix():
+    t = _make(nodes=[
+        {"id": "x", "type": "X", "properties": {}, "parent_id": None, "contains": [], "metric_level": "ULTRA_MODULE", "dimension": "d"},
+    ])
+    r = _run(t)
+    assert "INVALID_METRIC_FORMAT" in _errors(r)
+
+
+# ─── Rule 10: Subject-Operation Compatibility ─────────────────────────────────
+
+def test_rule_10_actor_can_do_anything():
+    t = _make_v091(
+        nodes=[
+            {"id": "p", "type": "PARTY", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_ACTOR", "dimension": "d"},
+            {"id": "d", "type": "DATA", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_DATA", "dimension": "d"},
+        ],
+        edges=[{"from_id": "p", "to_id": "d", "relation": "FILTER"}],
+    )
+    r = _run(t)
+    assert "INCOMPATIBLE_SUBJECT_OPERATION" not in _errors(r)
+
+
+def test_rule_10_artifact_cannot_transform():
+    t = _make_v091(
+        nodes=[
+            {"id": "d", "type": "DATA", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_DATA", "dimension": "d"},
+            {"id": "d2", "type": "RECORD", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_RECORD", "dimension": "d"},
+        ],
+        edges=[{"from_id": "d", "to_id": "d2", "relation": "FILTER"}],
+    )
+    r = _run(t)
+    assert "INCOMPATIBLE_SUBJECT_OPERATION" in _errors(r)
+
+
+def test_rule_10_artifact_can_exists():
+    t = _make_v091(
+        nodes=[
+            {"id": "d", "type": "DATA", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_DATA", "dimension": "d"},
+        ],
+        edges=[{"from_id": "d", "to_id": "d", "relation": "EXISTS"}],
+    )
+    r = _run(t)
+    assert "INCOMPATIBLE_SUBJECT_OPERATION" not in _errors(r)
+
+
+def test_rule_10_container_can_transform():
+    t = _make_v091(
+        nodes=[
+            {"id": "pipe", "type": "PIPELINE", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_PIPE", "dimension": "d"},
+            {"id": "d", "type": "DATA", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_DATA", "dimension": "d"},
+        ],
+        edges=[{"from_id": "pipe", "to_id": "d", "relation": "FILTER"}],
+    )
+    r = _run(t)
+    assert "INCOMPATIBLE_SUBJECT_OPERATION" not in _errors(r)
+
+
+def test_rule_10_not_triggered_without_v091():
+    """Rules 10-16 only fire with core_v1.0.0 capability."""
+    t = _make(
+        nodes=[
+            {"id": "d", "type": "DATA", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_DATA", "dimension": "d"},
+        ],
+        edges=[{"from_id": "d", "to_id": "d", "relation": "FILTER"}],
+    )
+    r = _run(t)
+    assert "INCOMPATIBLE_SUBJECT_OPERATION" not in _errors(r)
+
+
+# ─── Rule 11: Operation-Object Compatibility ──────────────────────────────────
+
+def test_rule_11_transform_on_artifact():
+    t = _make_v091(
+        nodes=[
+            {"id": "p", "type": "PARTY", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_ACTOR", "dimension": "d"},
+            {"id": "d", "type": "DATA", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_DATA", "dimension": "d"},
+        ],
+        edges=[{"from_id": "p", "to_id": "d", "relation": "FILTER"}],
+    )
+    r = _run(t)
+    assert "INCOMPATIBLE_OPERATION_OBJECT" not in _errors(r)
+
+
+def test_rule_11_transform_on_actor_fails():
+    t = _make_v091(
+        nodes=[
+            {"id": "p1", "type": "PARTY", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_ACTOR", "dimension": "d"},
+            {"id": "p2", "type": "AGENT", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_AGENT", "dimension": "d"},
+        ],
+        edges=[{"from_id": "p1", "to_id": "p2", "relation": "FILTER"}],
+    )
+    r = _run(t)
+    assert "INCOMPATIBLE_OPERATION_OBJECT" in _errors(r)
+
+
+def test_rule_11_permit_on_actor():
+    t = _make_v091(
+        nodes=[
+            {"id": "p1", "type": "PARTY", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_ACTOR", "dimension": "d"},
+            {"id": "p2", "type": "AGENT", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_AGENT", "dimension": "d"},
+        ],
+        edges=[{"from_id": "p1", "to_id": "p2", "relation": "GRANT"}],
+    )
+    r = _run(t)
+    assert "INCOMPATIBLE_OPERATION_OBJECT" not in _errors(r)
+
+
+def test_rule_11_resolve_on_outcome():
+    t = _make_v091(
+        nodes=[
+            {"id": "p", "type": "PARTY", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_ACTOR", "dimension": "d"},
+            {"id": "e", "type": "ERROR", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_ERR", "dimension": "d"},
+        ],
+        edges=[{"from_id": "p", "to_id": "e", "relation": "HANDLE"}],
+    )
+    r = _run(t)
+    assert "INCOMPATIBLE_OPERATION_OBJECT" not in _errors(r)
+
+
+# ─── Rule 14: Constraint-Subject ───────────────────────────────────────────────
+
+def test_rule_14_modal_on_actor():
+    t = _make_v091(
+        edges=[{"from_id": "system", "to_id": "system", "relation": "SHALL"}],
+    )
+    r = _run(t)
+    assert "CONSTRAINT_REQUIRES_ACTOR" not in _errors(r)
+
+
+def test_rule_14_modal_on_non_actor():
+    t = _make_v091(
+        nodes=[
+            {"id": "d", "type": "DATA", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_DATA", "dimension": "d"},
+        ],
+        edges=[{"from_id": "d", "to_id": "d", "relation": "SHALL"}],
+    )
+    r = _run(t)
+    assert "CONSTRAINT_REQUIRES_ACTOR" in _errors(r)
+
+
+# ─── Rule 15: No Double Negation ──────────────────────────────────────────────
+
+def test_rule_15_no_double_neg():
+    t = _make_v091(
+        nodes=[
+            {"id": "p", "type": "PARTY", "properties": {"scope": {"quantifier": "NO"}}, "parent_id": None, "contains": [], "metric_level": "BASE_ACTOR", "dimension": "d"},
+        ],
+        edges=[{"from_id": "p", "to_id": "p", "relation": "SHALL_NOT"}],
+    )
+    r = _run(t)
+    assert "DOUBLE_NEGATION" in _errors(r)
+
+
+def test_rule_15_single_neg_ok():
+    t = _make_v091(
+        nodes=[
+            {"id": "p", "type": "PARTY", "properties": {"scope": {"quantifier": "ALL"}}, "parent_id": None, "contains": [], "metric_level": "BASE_ACTOR", "dimension": "d"},
+        ],
+        edges=[{"from_id": "p", "to_id": "p", "relation": "SHALL_NOT"}],
+    )
+    r = _run(t)
+    assert "DOUBLE_NEGATION" not in _errors(r)
+
+
+# ─── Rule 16: Reference Scope ─────────────────────────────────────────────────
+
+def test_rule_16_resolved_reference():
+    t = _make_v091(
+        nodes=[
+            {"id": "p", "type": "PARTY", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_ACTOR", "dimension": "d"},
+            {"id": "SELF", "type": "DATA", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_REF", "dimension": "d"},
+        ],
+        edges=[{"from_id": "p", "to_id": "SELF", "relation": "REFERENCES"}],
+    )
+    r = _run(t)
+    assert "UNRESOLVED_REFERENCE" not in _errors(r)
+
+
+def test_rule_16_unresolved_reference():
+    t = _make_v091(
+        edges=[{"from_id": "system", "to_id": "RESULT", "relation": "REFERENCES"}],
+    )
+    r = _run(t)
+    assert "UNRESOLVED_REFERENCE" in _errors(r)
+
+
+# ─── Integration: validate_file ────────────────────────────────────────────────
+
+def test_validate_file_valid():
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".trug.json", delete=False) as f:
+        json.dump(MINIMAL_VALID, f)
+        f.flush()
+        r = validate_file(Path(f.name))
+    assert r.valid
+
+
+def test_validate_file_invalid_json():
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        f.write("{bad json")
+        f.flush()
+        r = validate_file(Path(f.name))
+    assert not r.valid
+    assert "PARSE_ERROR" in _errors(r)
+
+
+def test_validate_file_not_found():
+    r = validate_file(Path("/nonexistent/path.json"))
+    assert not r.valid
+    assert "FILE_NOT_FOUND" in _errors(r)
+
+
+# ─── Integration: Full validate ────────────────────────────────────────────────
+
+def test_minimal_valid_passes():
+    r = validate(MINIMAL_VALID)
+    assert r.valid
+
+
+def test_minimal_v091_passes():
+    r = validate(MINIMAL_V091)
+    assert r.valid
+
+
+def test_not_a_dict():
+    r = validate([1, 2, 3])
+    assert not r.valid
+    assert "INVALID_ROOT" in _errors(r)
+
+
+def test_v091_opt_in():
+    """core_v1.0.0 rules only fire when declared."""
+    # This TRUG has DATA doing FILTER (invalid under rule 10) but no core_v1.0.0
+    t = _make(
+        nodes=[
+            {"id": "d", "type": "DATA", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_DATA", "dimension": "d"},
+        ],
+        edges=[{"from_id": "d", "to_id": "d", "relation": "FILTER"}],
+    )
+    r = validate(t)
+    assert r.valid  # No compositional rules fired
+
+    # Same TRUG with core_v1.0.0 — should fail
+    t["capabilities"]["vocabularies"] = ["core_v1.0.0"]
+    r = validate(t)
+    assert not r.valid
+
+
+# ─── Run ───────────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    import sys
+    tests = [(name, obj) for name, obj in globals().items() if name.startswith("test_") and callable(obj)]
+    passed = 0
+    failed = 0
+    for name, fn in sorted(tests):
+        try:
+            fn()
+            passed += 1
+            print(f"  PASS  {name}")
+        except AssertionError as e:
+            failed += 1
+            print(f"  FAIL  {name}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"  ERROR {name}: {type(e).__name__}: {e}")
+    print(f"\n{passed + failed} tests: {passed} passed, {failed} failed")
+    sys.exit(1 if failed else 0)

--- a/installers/npm/templates/tools/validate.py
+++ b/installers/npm/templates/tools/validate.py
@@ -1,0 +1,526 @@
+"""TRUGS validator — enforces all 16 CORE rules.
+
+Rules 1-9: Structural (always enforced)
+Rules 10-16: Compositional (enforced when core_v1.0.0 declared)
+
+Usage:
+    python -m trugs_llc.tools.validate <file.trug.json>
+    python -m trugs_llc.tools.validate --all <directory>
+"""
+
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+
+# ─── Primitives ────────────────────────────────────────────────────────────────
+# From TRUGS_LLC/TRUGS_LANGUAGE/SPEC_vocabulary.md
+
+ENTITY_ACTORS = {"TRANSFORM", "PARTY", "AGENT", "PRINCIPAL", "PROCESS", "SERVICE", "FUNCTION"}
+ENTITY_ARTIFACTS = {"DATA", "FILE", "RECORD", "MESSAGE", "STREAM", "RESOURCE", "INSTRUMENT"}
+ENTITY_CONTAINERS = {"PIPELINE", "STAGE", "MODULE", "NAMESPACE"}
+ENTITY_BOUNDARIES = {"ENTRY", "FLOW_ENTRY", "EXIT", "FLOW_EXIT", "INTERFACE", "ENDPOINT", "JURISDICTION", "DEADLINE"}
+ENTITY_OUTCOMES = {"RESULT", "ERROR", "EXCEPTION", "REMEDY"}
+
+ALL_ENTITIES = ENTITY_ACTORS | ENTITY_ARTIFACTS | ENTITY_CONTAINERS | ENTITY_BOUNDARIES | ENTITY_OUTCOMES
+
+OP_TRANSFORM = {"FILTER", "EXCLUDE", "MAP", "SORT", "MERGE", "SPLIT", "FLATTEN", "AGGREGATE", "GROUP", "RENAME", "BATCH", "DISTINCT", "TAKE", "SKIP"}
+OP_MOVE = {"READ", "WRITE", "SEND", "RECEIVE", "RETURN", "REQUEST", "RESPOND", "AUTHENTICATE", "DELIVER", "ASSIGN"}
+OP_OBLIGATE = {"VALIDATE", "ASSERT", "REQUIRE", "SHALL"}
+OP_PERMIT = {"ALLOW", "APPROVE", "GRANT", "OVERRIDE", "MAY"}
+OP_PROHIBIT = {"DENY", "REJECT", "SHALL_NOT", "REVOKE"}
+OP_CONTROL = {"BRANCH", "MATCH", "RETRY", "TIMEOUT", "THROW", "EXISTS", "EXPIRE", "EQUALS", "EXCEEDS", "PRECEDES"}
+OP_CONTROL_COMPARISON = {"EXISTS", "EQUALS", "EXCEEDS", "PRECEDES", "EXPIRE"}
+OP_BIND = {"DEFINE", "DECLARE", "IMPLEMENT", "NEST", "AUGMENT", "REPLACE", "CITE", "ADMINISTER", "STIPULATE"}
+OP_RESOLVE = {"CATCH", "HANDLE", "RECOVER", "CURE", "INDEMNIFY"}
+
+ALL_OPERATIONS = OP_TRANSFORM | OP_MOVE | OP_OBLIGATE | OP_PERMIT | OP_PROHIBIT | OP_CONTROL | OP_BIND | OP_RESOLVE
+
+MODALS = {"SHALL", "SHALL_NOT", "MAY"}
+
+MOD_TYPE = {"STRING", "INTEGER", "BOOLEAN", "ARRAY", "OBJECT"}
+MOD_ACCESS = {"PUBLIC", "PRIVATE", "PROTECTED", "READONLY", "CONFIDENTIAL"}
+MOD_STATE = {"VALID", "INVALID", "NULL", "EMPTY", "PENDING", "ACTIVE", "FAILED", "MUTABLE", "IMMUTABLE", "BINDING", "VOID", "ENFORCEABLE", "EXPIRED", "PRECEDENT"}
+MOD_QUANTITY = {"REQUIRED", "OPTIONAL", "UNIQUE", "MULTIPLE", "SOLE", "JOINT"}
+MOD_PRIORITY = {"DEFAULT", "CRITICAL", "HIGH", "LOW", "MATERIAL", "SUBORDINATE"}
+
+QUAL_TIMING = {"ASYNC", "SYNC", "SEQUENTIAL", "PARALLEL", "IMMEDIATE", "LAZY", "PROMPTLY", "FORTHWITH", "WITHIN"}
+QUAL_REPETITION = {"ONCE", "ALWAYS", "NEVER", "BOUNDED"}
+QUAL_DEGREE = {"STRICTLY", "PARTIALLY", "SUBSTANTIALLY", "REASONABLY"}
+QUAL_CONDITION = {"UNCONDITIONALLY", "CONDITIONALLY"}
+
+SELECTOR_NEGATIVE = {"NO", "NONE"}
+
+SI_PREFIXES = {
+    "YOTTA", "ZETTA", "EXA", "PETA", "TERA", "GIGA", "MEGA",
+    "KILO", "HECTO", "DEKA", "BASE", "DECI", "CENTI", "MILLI",
+    "MICRO", "NANO", "PICO", "FEMTO", "ATTO", "ZEPTO", "YOCTO"
+}
+
+SI_VALUES = {
+    "YOTTA": 1e24, "ZETTA": 1e21, "EXA": 1e18, "PETA": 1e15,
+    "TERA": 1e12, "GIGA": 1e9, "MEGA": 1e6, "KILO": 1e3,
+    "HECTO": 1e2, "DEKA": 1e1, "BASE": 1e0, "DECI": 1e-1,
+    "CENTI": 1e-2, "MILLI": 1e-3, "MICRO": 1e-6, "NANO": 1e-9,
+    "PICO": 1e-12, "FEMTO": 1e-15, "ATTO": 1e-18,
+    "ZEPTO": 1e-21, "YOCTO": 1e-24
+}
+
+
+# ─── Result Types ──────────────────────────────────────────────────────────────
+
+@dataclass
+class ValidationError:
+    code: str
+    message: str
+    location: str = ""
+    node_id: Optional[str] = None
+
+
+@dataclass
+class ValidationResult:
+    errors: List[ValidationError] = field(default_factory=list)
+    warnings: List[ValidationError] = field(default_factory=list)
+
+    @property
+    def valid(self) -> bool:
+        return len(self.errors) == 0
+
+    def error(self, code: str, message: str, location: str = "", node_id: Optional[str] = None):
+        self.errors.append(ValidationError(code, message, location, node_id))
+
+    def warn(self, code: str, message: str, location: str = "", node_id: Optional[str] = None):
+        self.warnings.append(ValidationError(code, message, location, node_id))
+
+    def summary(self) -> str:
+        if self.valid and not self.warnings:
+            return "VALID"
+        parts = []
+        if self.errors:
+            parts.append(f"{len(self.errors)} errors")
+        if self.warnings:
+            parts.append(f"{len(self.warnings)} warnings")
+        return ", ".join(parts)
+
+
+# ─── Helpers ───────────────────────────────────────────────────────────────────
+
+def _entity_class(node_type: str) -> Optional[str]:
+    if node_type in ENTITY_ACTORS:
+        return "Actor"
+    if node_type in ENTITY_ARTIFACTS:
+        return "Artifact"
+    if node_type in ENTITY_CONTAINERS:
+        return "Container"
+    if node_type in ENTITY_BOUNDARIES:
+        return "Boundary"
+    if node_type in ENTITY_OUTCOMES:
+        return "Outcome"
+    return None
+
+
+def _op_class(operation: str) -> Optional[str]:
+    if operation in OP_TRANSFORM:
+        return "Transform"
+    if operation in OP_MOVE:
+        return "Move"
+    if operation in OP_OBLIGATE:
+        return "Obligate"
+    if operation in OP_PERMIT:
+        return "Permit"
+    if operation in OP_PROHIBIT:
+        return "Prohibit"
+    if operation in OP_CONTROL:
+        return "Control"
+    if operation in OP_BIND:
+        return "Bind"
+    if operation in OP_RESOLVE:
+        return "Resolve"
+    return None
+
+
+def _has_core_v091(trug: Dict[str, Any]) -> bool:
+    caps = trug.get("capabilities", {})
+    vocabs = caps.get("vocabularies", [])
+    return "core_v1.0.0" in vocabs
+
+
+# ─── Rules 1-9: Structural ────────────────────────────────────────────────────
+
+def rule_1_unique_ids(trug: Dict[str, Any], r: ValidationResult):
+    seen: Set[str] = set()
+    for i, node in enumerate(trug.get("nodes", [])):
+        nid = node.get("id")
+        if not nid:
+            r.error("MISSING_NODE_ID", f"nodes[{i}] missing 'id'", f"nodes[{i}]")
+        elif nid in seen:
+            r.error("DUPLICATE_NODE_ID", f"Duplicate node ID '{nid}'", f"nodes[{i}]", nid)
+        else:
+            seen.add(nid)
+
+
+def rule_2_edge_id_validity(trug: Dict[str, Any], r: ValidationResult):
+    node_ids = {n.get("id") for n in trug.get("nodes", []) if n.get("id")}
+    for i, edge in enumerate(trug.get("edges", [])):
+        fid = edge.get("from_id")
+        tid = edge.get("to_id")
+        if fid and fid not in node_ids:
+            r.error("INVALID_EDGE_REFERENCE", f"Edge from_id '{fid}' not found", f"edges[{i}]")
+        if tid and ":" not in str(tid) and tid not in node_ids:
+            r.error("INVALID_EDGE_REFERENCE", f"Edge to_id '{tid}' not found", f"edges[{i}]")
+
+
+def rule_3_hierarchy_consistency(trug: Dict[str, Any], r: ValidationResult):
+    node_map = {n.get("id"): n for n in trug.get("nodes", []) if n.get("id")}
+    for nid, node in node_map.items():
+        pid = node.get("parent_id")
+        if pid and pid in node_map:
+            parent = node_map[pid]
+            if nid not in parent.get("contains", []):
+                r.error("INCONSISTENT_HIERARCHY", f"'{nid}' has parent_id='{pid}' but parent's contains[] missing it", node_id=nid)
+        for cid in node.get("contains", []):
+            if cid in node_map:
+                child = node_map[cid]
+                if child.get("parent_id") != nid:
+                    r.error("INCONSISTENT_HIERARCHY", f"'{nid}' lists '{cid}' in contains[] but child's parent_id='{child.get('parent_id')}'", node_id=nid)
+
+
+def rule_4_metric_level_ordering(trug: Dict[str, Any], r: ValidationResult):
+    node_map = {n.get("id"): n for n in trug.get("nodes", []) if n.get("id")}
+    for nid, node in node_map.items():
+        pid = node.get("parent_id")
+        if not pid or pid not in node_map:
+            continue
+        parent = node_map[pid]
+        p_ml = parent.get("metric_level", "")
+        c_ml = node.get("metric_level", "")
+        p_prefix = p_ml.split("_")[0] if "_" in p_ml else ""
+        c_prefix = c_ml.split("_")[0] if "_" in c_ml else ""
+        if p_prefix in SI_VALUES and c_prefix in SI_VALUES:
+            if SI_VALUES[p_prefix] < SI_VALUES[c_prefix]:
+                r.error("INVALID_METRIC_ORDERING", f"Parent '{pid}' ({p_ml}) < child '{nid}' ({c_ml})", node_id=nid)
+
+
+def rule_5_dimension_declaration(trug: Dict[str, Any], r: ValidationResult):
+    dims = trug.get("dimensions", {})
+    if not isinstance(dims, dict):
+        return  # Malformed dimensions — rule_7 will catch the type error
+    declared = set(dims.keys())
+    for i, node in enumerate(trug.get("nodes", [])):
+        dim = node.get("dimension")
+        if dim and dim not in declared:
+            r.error("UNDECLARED_DIMENSION", f"Node '{node.get('id')}' uses undeclared dimension '{dim}'", node_id=node.get("id"))
+
+
+def rule_6_required_fields(trug: Dict[str, Any], r: ValidationResult):
+    # Root fields checked separately in validate() for early return
+    node_fields = ["id", "type", "properties", "parent_id", "contains", "metric_level"]
+    for i, node in enumerate(trug.get("nodes", [])):
+        for f in node_fields:
+            if f not in node:
+                r.error("MISSING_REQUIRED_FIELD", f"Node '{node.get('id', i)}' missing field '{f}'", f"nodes[{i}]", node.get("id"))
+    edge_fields = ["from_id", "to_id", "relation"]
+    for i, edge in enumerate(trug.get("edges", [])):
+        for f in edge_fields:
+            if f not in edge:
+                r.error("MISSING_REQUIRED_FIELD", f"Edge [{i}] missing field '{f}'", f"edges[{i}]")
+
+
+def rule_7_field_type_correctness(trug: Dict[str, Any], r: ValidationResult):
+    for i, node in enumerate(trug.get("nodes", [])):
+        nid = node.get("id", f"nodes[{i}]")
+        if "id" in node and not isinstance(node["id"], str):
+            r.error("INVALID_FIELD_TYPE", f"Node '{nid}': id must be string", node_id=nid)
+        if "type" in node and not isinstance(node["type"], str):
+            r.error("INVALID_FIELD_TYPE", f"Node '{nid}': type must be string", node_id=nid)
+        if "properties" in node and not isinstance(node["properties"], dict):
+            r.error("INVALID_FIELD_TYPE", f"Node '{nid}': properties must be object", node_id=nid)
+        if "parent_id" in node and node["parent_id"] is not None and not isinstance(node["parent_id"], str):
+            r.error("INVALID_FIELD_TYPE", f"Node '{nid}': parent_id must be string or null", node_id=nid)
+        if "contains" in node and not isinstance(node["contains"], list):
+            r.error("INVALID_FIELD_TYPE", f"Node '{nid}': contains must be array", node_id=nid)
+        if "metric_level" in node and not isinstance(node["metric_level"], str):
+            r.error("INVALID_FIELD_TYPE", f"Node '{nid}': metric_level must be string", node_id=nid)
+    for i, edge in enumerate(trug.get("edges", [])):
+        for f in ["from_id", "to_id", "relation"]:
+            if f in edge and not isinstance(edge[f], str):
+                r.error("INVALID_FIELD_TYPE", f"Edge [{i}]: {f} must be string", f"edges[{i}]")
+        if "weight" in edge:
+            w = edge["weight"]
+            if not isinstance(w, (int, float)) or isinstance(w, bool):
+                r.error("INVALID_EDGE_WEIGHT", f"Edge [{i}]: weight must be number 0.0-1.0", f"edges[{i}]")
+            elif w < 0.0 or w > 1.0:
+                r.error("INVALID_EDGE_WEIGHT", f"Edge [{i}]: weight {w} outside 0.0-1.0", f"edges[{i}]")
+
+
+def rule_8_extension_declaration(trug: Dict[str, Any], r: ValidationResult):
+    declared_ext = set(trug.get("capabilities", {}).get("extensions", []))
+    for i, node in enumerate(trug.get("nodes", [])):
+        props = node.get("properties", {})
+        if "type_info" in props and "typed" not in declared_ext:
+            r.error("UNDECLARED_EXTENSION", f"Node '{node.get('id')}' uses typed extension but it's not declared", node_id=node.get("id"))
+
+
+def rule_9_metric_level_format(trug: Dict[str, Any], r: ValidationResult):
+    for i, node in enumerate(trug.get("nodes", [])):
+        ml = node.get("metric_level")
+        if not ml or not isinstance(ml, str):
+            continue
+        if "_" not in ml:
+            r.error("INVALID_METRIC_FORMAT", f"metric_level '{ml}' must be PREFIX_NAME", node_id=node.get("id"))
+            continue
+        prefix = ml.split("_")[0]
+        if prefix not in SI_PREFIXES:
+            r.error("INVALID_METRIC_FORMAT", f"Invalid SI prefix '{prefix}' in '{ml}'", node_id=node.get("id"))
+
+
+# ─── Rules 10-16: Compositional (opt-in via core_v1.0.0) ──────────────────────
+
+def rule_10_subject_operation(trug: Dict[str, Any], r: ValidationResult):
+    """Subject-Operation compatibility."""
+    node_map = {n.get("id"): n for n in trug.get("nodes", []) if n.get("id")}
+    for edge in trug.get("edges", []):
+        rel = edge.get("relation", "")
+        if rel not in MODALS and rel not in ALL_OPERATIONS:
+            continue
+        fid = edge.get("from_id")
+        if fid not in node_map:
+            continue
+        subject_type = node_map[fid].get("type", "")
+        ec = _entity_class(subject_type)
+        if not ec:
+            continue
+        op = rel if rel in ALL_OPERATIONS else None
+        if not op:
+            continue
+        oc = _op_class(op)
+        if ec == "Actor":
+            continue  # Actors can do anything
+        if ec == "Container" and oc in ("Transform", "Control", "Bind"):
+            continue
+        if ec == "Artifact" and oc == "Control" and op in OP_CONTROL_COMPARISON:
+            continue
+        if ec == "Boundary" and oc == "Bind":
+            continue
+        r.error("INCOMPATIBLE_SUBJECT_OPERATION", f"'{subject_type}' ({ec}) cannot perform '{op}' ({oc})", node_id=fid)
+
+
+def rule_11_operation_object(trug: Dict[str, Any], r: ValidationResult):
+    """Operation-Object compatibility."""
+    node_map = {n.get("id"): n for n in trug.get("nodes", []) if n.get("id")}
+    for edge in trug.get("edges", []):
+        rel = edge.get("relation", "")
+        if rel not in ALL_OPERATIONS:
+            continue
+        tid = edge.get("to_id")
+        if tid not in node_map:
+            continue
+        obj_type = node_map[tid].get("type", "")
+        ec = _entity_class(obj_type)
+        if not ec:
+            continue
+        oc = _op_class(rel)
+        if ec == "Artifact" and oc in ("Transform", "Move", "Obligate", "Control", "Bind"):
+            continue
+        if ec == "Actor" and oc in ("Permit", "Prohibit"):
+            continue
+        if ec == "Container" and oc in ("Move", "Bind"):
+            continue
+        if ec == "Boundary" and oc == "Bind":
+            continue
+        if ec == "Outcome" and oc == "Resolve":
+            continue
+        r.error("INCOMPATIBLE_OPERATION_OBJECT", f"'{obj_type}' ({ec}) cannot be target of '{rel}' ({oc})", node_id=tid)
+
+
+def rule_12_modifier_entity(trug: Dict[str, Any], r: ValidationResult):
+    """Modifier-Entity compatibility."""
+    for node in trug.get("nodes", []):
+        nid = node.get("id", "?")
+        ntype = node.get("type", "")
+        ec = _entity_class(ntype)
+        if not ec:
+            continue
+        props = node.get("properties", {})
+        for key, val in props.items():
+            if not isinstance(val, str):
+                continue
+            v = val.upper()
+            if v in MOD_TYPE and ec not in ("Artifact", "Outcome"):
+                r.error("INCOMPATIBLE_MODIFIER_ENTITY", f"Type modifier '{val}' on {ec} '{nid}'", node_id=nid)
+            if v in MOD_ACCESS and ec in ("Actor", "Outcome"):
+                r.error("INCOMPATIBLE_MODIFIER_ENTITY", f"Access modifier '{val}' on {ec} '{nid}'", node_id=nid)
+            if v in MOD_QUANTITY and ec == "Boundary":
+                r.error("INCOMPATIBLE_MODIFIER_ENTITY", f"Quantity modifier '{val}' on {ec} '{nid}'", node_id=nid)
+
+
+def rule_13_qualifier_operation(trug: Dict[str, Any], r: ValidationResult):
+    """Qualifier-Operation compatibility."""
+    for node in trug.get("nodes", []):
+        ntype = node.get("type", "")
+        if ntype != "TRANSFORM":
+            continue
+        nid = node.get("id", "?")
+        props = node.get("properties", {})
+        op = props.get("operation", "")
+        oc = _op_class(op)
+        if not oc:
+            continue
+        for key, val in props.items():
+            if not isinstance(val, str):
+                continue
+            v = val.upper()
+            if v in QUAL_TIMING and oc == "Bind":
+                r.error("INCOMPATIBLE_QUALIFIER_OPERATION", f"Timing qualifier '{val}' on Bind operation '{op}' in '{nid}'", node_id=nid)
+            if v in QUAL_REPETITION and oc == "Bind":
+                r.error("INCOMPATIBLE_QUALIFIER_OPERATION", f"Repetition qualifier '{val}' on Bind operation '{op}' in '{nid}'", node_id=nid)
+            if v in QUAL_DEGREE and oc in ("Transform", "Move", "Control", "Resolve"):
+                r.error("INCOMPATIBLE_QUALIFIER_OPERATION", f"Degree qualifier '{val}' on {oc} operation '{op}' in '{nid}'", node_id=nid)
+
+
+def rule_14_constraint_subject(trug: Dict[str, Any], r: ValidationResult):
+    """Modals (SHALL, SHALL_NOT, MAY) require Actor subjects."""
+    node_map = {n.get("id"): n for n in trug.get("nodes", []) if n.get("id")}
+    for edge in trug.get("edges", []):
+        rel = edge.get("relation", "")
+        if rel not in MODALS:
+            continue
+        fid = edge.get("from_id")
+        if fid not in node_map:
+            continue
+        subject_type = node_map[fid].get("type", "")
+        if subject_type not in ENTITY_ACTORS:
+            r.error("CONSTRAINT_REQUIRES_ACTOR", f"Modal '{rel}' on non-Actor '{subject_type}' node '{fid}'", node_id=fid)
+
+
+def rule_15_no_double_negation(trug: Dict[str, Any], r: ValidationResult):
+    """Negative selector + Prohibit modal = double negation."""
+    node_map = {n.get("id"): n for n in trug.get("nodes", []) if n.get("id")}
+    for edge in trug.get("edges", []):
+        if edge.get("relation") != "SHALL_NOT":
+            continue
+        fid = edge.get("from_id")
+        if fid not in node_map:
+            continue
+        props = node_map[fid].get("properties", {})
+        scope = props.get("scope", {})
+        quantifier = scope.get("quantifier", "") if isinstance(scope, dict) else ""
+        if quantifier.upper() in SELECTOR_NEGATIVE:
+            r.error("DOUBLE_NEGATION", f"Double negation: '{quantifier}' + SHALL_NOT on '{fid}'", node_id=fid)
+
+
+def rule_16_reference_scope(trug: Dict[str, Any], r: ValidationResult):
+    """References (SELF, RESULT, etc.) must resolve within subgraph scope."""
+    references = {"SELF", "RESULT", "OUTPUT", "INPUT", "SOURCE", "TARGET", "SAID"}
+    node_ids = {n.get("id") for n in trug.get("nodes", []) if n.get("id")}
+    for edge in trug.get("edges", []):
+        if edge.get("relation") != "REFERENCES":
+            continue
+        tid = edge.get("to_id", "")
+        if tid.upper() in references and tid not in node_ids:
+            r.error("UNRESOLVED_REFERENCE", f"Reference '{tid}' does not resolve to a node", f"edge to '{tid}'")
+
+
+# ─── Main Validator ────────────────────────────────────────────────────────────
+
+def validate(trug: Dict[str, Any]) -> ValidationResult:
+    """Validate a TRUG against all applicable CORE rules."""
+    r = ValidationResult()
+
+    if not isinstance(trug, dict):
+        r.error("INVALID_ROOT", "TRUG must be a JSON object")
+        return r
+
+    # Check root structure first — can't proceed without nodes/edges
+    for root_field in ["name", "version", "type", "nodes", "edges"]:
+        if root_field not in trug:
+            r.error("MISSING_REQUIRED_FIELD", f"Missing root field '{root_field}'", "root")
+    if not r.valid:
+        return r
+
+    # Rules 1-9: always enforced
+    rule_6_required_fields(trug, r)
+
+    rule_1_unique_ids(trug, r)
+    rule_2_edge_id_validity(trug, r)
+    rule_3_hierarchy_consistency(trug, r)
+    rule_4_metric_level_ordering(trug, r)
+    rule_5_dimension_declaration(trug, r)
+    rule_7_field_type_correctness(trug, r)
+    rule_8_extension_declaration(trug, r)
+    rule_9_metric_level_format(trug, r)
+
+    # Rules 10-16: only when core_v1.0.0 declared
+    if _has_core_v091(trug):
+        rule_10_subject_operation(trug, r)
+        rule_11_operation_object(trug, r)
+        rule_12_modifier_entity(trug, r)
+        rule_13_qualifier_operation(trug, r)
+        rule_14_constraint_subject(trug, r)
+        rule_15_no_double_negation(trug, r)
+        rule_16_reference_scope(trug, r)
+
+    return r
+
+
+def validate_file(path: Path) -> ValidationResult:
+    """Load and validate a .trug.json file."""
+    r = ValidationResult()
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            trug = json.load(f)
+    except json.JSONDecodeError as e:
+        r.error("PARSE_ERROR", f"Invalid JSON: {e}", str(path))
+        return r
+    except FileNotFoundError:
+        r.error("FILE_NOT_FOUND", f"File not found: {path}", str(path))
+        return r
+    return validate(trug)
+
+
+# ─── CLI ───────────────────────────────────────────────────────────────────────
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python -m trugs_llc.tools.validate <file.trug.json> [--all <dir>]")
+        sys.exit(1)
+
+    if sys.argv[1] == "--all":
+        directory = Path(sys.argv[2]) if len(sys.argv) > 2 else Path(".")
+        files = sorted(set(directory.rglob("*.trug.json")) | set(directory.rglob("*.json")))
+        if not files:
+            print(f"No .trug.json files found in {directory}")
+            sys.exit(1)
+        total_errors = 0
+        for f in files:
+            result = validate_file(f)
+            status = "PASS" if result.valid else "FAIL"
+            print(f"  {status}  {f}  ({result.summary()})")
+            total_errors += len(result.errors)
+            for err in result.errors:
+                print(f"         {err.code}: {err.message}")
+            for warn in result.warnings:
+                print(f"         WARN {warn.code}: {warn.message}")
+        print(f"\n{len(files)} files checked, {total_errors} errors")
+        sys.exit(1 if total_errors > 0 else 0)
+    else:
+        path = Path(sys.argv[1])
+        result = validate_file(path)
+        if result.valid:
+            print(f"VALID  {path}")
+            for warn in result.warnings:
+                print(f"  WARN {warn.code}: {warn.message}")
+            sys.exit(0)
+        else:
+            print(f"INVALID  {path}")
+            for err in result.errors:
+                print(f"  ERROR {err.code}: {err.message}")
+            for warn in result.warnings:
+                print(f"  WARN {warn.code}: {warn.message}")
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/installers/pip/README.md
+++ b/installers/pip/README.md
@@ -1,0 +1,44 @@
+# TRUGS Agent
+
+A 190-word formal instruction language for LLM coding assistants. Your AI stops interpreting and starts executing.
+
+## Install
+
+```bash
+pip install trugs-agent
+```
+
+## Usage
+
+```bash
+# Initialize for Claude Code (default)
+trugs-agent-init
+
+# Initialize for Cursor
+trugs-agent-init cursor
+
+# Initialize for GitHub Copilot
+trugs-agent-init copilot
+```
+
+This copies AGENT.md (renamed for your IDE) and all component folders into the current directory. Your LLM reads the files and gains the TRL vocabulary — 190 words with exact definitions.
+
+## What You Get
+
+- **AGENT.md** — TRL vocabulary and grammar (the core)
+- **AAA/** — 9-phase development protocol
+- **EPIC/** — Portfolio tracking as a graph
+- **FOLDER/** — Machine-readable filesystem index
+- **MEMORY/** — Persistent context across sessions
+- **SKILLS/** — 19 composable agent primitives
+- **TRUGGING/** — Codebase description methodology
+- **WEB_HUB/** — Curated web resource graph
+- **tools/** — Zero-dependency TRUGS validator
+
+## Links
+
+- [GitHub](https://github.com/TRUGS-LLC/TRUGS-AGENT)
+- [Full Specification](https://github.com/TRUGS-LLC/TRUGS)
+- [Paper](https://github.com/TRUGS-LLC/TRUGS/blob/main/PAPER/trugs.pdf)
+
+Apache 2.0 — TRUGS LLC

--- a/installers/pip/pyproject.toml
+++ b/installers/pip/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "trugs-agent"
+version = "1.0.0"
+description = "Initialize TRUGS Agent in your project — a 190-word formal instruction language for LLM coding assistants"
+readme = "README.md"
+license = "Apache-2.0"
+authors = [
+    { name = "TRUGS LLC" }
+]
+keywords = [
+    "trugs", "trl", "llm", "ai-agents", "claude-code",
+    "cursor", "copilot", "developer-tools", "prompt-engineering"
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Topic :: Software Development :: Libraries",
+]
+requires-python = ">=3.8"
+
+[project.scripts]
+trugs-agent-init = "trugs_agent.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/TRUGS-LLC/TRUGS-AGENT"
+Repository = "https://github.com/TRUGS-LLC/TRUGS-AGENT"
+Issues = "https://github.com/TRUGS-LLC/TRUGS-AGENT/issues"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+trugs_agent = ["templates/**/*"]

--- a/installers/pip/src/trugs_agent/__init__.py
+++ b/installers/pip/src/trugs_agent/__init__.py
@@ -1,0 +1,3 @@
+"""TRUGS Agent — a 190-word formal instruction language for LLM coding assistants."""
+
+__version__ = "1.0.0"

--- a/installers/pip/src/trugs_agent/cli.py
+++ b/installers/pip/src/trugs_agent/cli.py
@@ -1,0 +1,74 @@
+"""Initialize TRUGS Agent in the current project directory."""
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+TEMPLATES = Path(__file__).parent / "templates"
+
+IDE_FILES = {
+    "claude": "CLAUDE.md",
+    "cursor": ".cursorrules",
+    "copilot": ".github/copilot-instructions.md",
+}
+
+COMPONENTS = ["AAA", "EPIC", "FOLDER", "MEMORY", "SKILLS", "TRUGGING", "WEB_HUB"]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Initialize TRUGS Agent in your project"
+    )
+    parser.add_argument(
+        "ide",
+        nargs="?",
+        default="claude",
+        choices=["claude", "cursor", "copilot"],
+        help="Target IDE (default: claude)",
+    )
+    args = parser.parse_args()
+
+    dest = Path.cwd()
+    target_file = IDE_FILES[args.ide]
+    target_path = dest / target_file
+
+    # Copy AGENT.md as IDE-specific file
+    agent_src = TEMPLATES / "AGENT.md"
+    if not agent_src.exists():
+        print(f"Error: templates not found at {TEMPLATES}", file=sys.stderr)
+        sys.exit(1)
+
+    if target_path.exists():
+        print(f"{target_file} already exists — skipping (won't overwrite)")
+    else:
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(agent_src, target_path)
+        print(f"Created {target_file}")
+
+    # Copy component folders
+    copied = 0
+    for comp in COMPONENTS:
+        src_dir = TEMPLATES / comp
+        dest_dir = dest / comp
+        if not src_dir.exists():
+            continue
+        if dest_dir.exists():
+            print(f"{comp}/ already exists — skipping")
+            continue
+        shutil.copytree(src_dir, dest_dir)
+        copied += 1
+        print(f"Created {comp}/")
+
+    # Copy validator
+    tools_src = TEMPLATES / "tools"
+    tools_dest = dest / "tools"
+    if tools_src.exists() and not tools_dest.exists():
+        shutil.copytree(tools_src, tools_dest)
+        print("Created tools/ (validator)")
+
+    print(f"\nTRUGS Agent initialized for {args.ide}. Your LLM now speaks TRL.")
+    print(f"  {target_file} — TRL vocabulary and grammar")
+    if copied > 0:
+        print(f"  {copied} component folders — methodology and tools")
+    print("\nFull docs: https://github.com/TRUGS-LLC/TRUGS-AGENT")

--- a/installers/pip/src/trugs_agent/templates/AAA/AGENT.md
+++ b/installers/pip/src/trugs_agent/templates/AAA/AGENT.md
@@ -1,0 +1,211 @@
+# AAA — Agent Instructions
+
+<trl>
+DEFINE "AAA" AS PIPELINE CONTAINS PHASE vision AND PHASE feasibility AND PHASE specifications AND PHASE architecture AND PHASE validation AND PHASE coding AND PHASE testing AND PHASE audit AND PHASE deployment.
+DEFINE "PLANNING" AS STAGE CONTAINS PHASE vision AND PHASE feasibility AND PHASE specifications AND PHASE architecture AND PHASE validation.
+DEFINE "EXECUTION" AS STAGE CONTAINS PHASE coding AND PHASE testing AND PHASE audit AND PHASE deployment.
+PIPELINE AAA CONTAINS STAGE PLANNING AND STAGE EXECUTION.
+</trl>
+
+AAA is a 9-phase development protocol. Two cycles, three human touchpoints. This file teaches you every phase, every rule, every gate.
+
+---
+
+## Two Paths — No Middle Ground
+
+<trl>
+IF AGENT KNOWS ALL REQUIRED STEP THEN AGENT SHALL EXECUTE AS RECORD chore.
+IF AGENT REQUIRES RECORD specification OR RECORD decision THEN AGENT SHALL CREATE RECORD issue THEN EXECUTE PHASE vision.
+NO AGENT SHALL CREATE RECORD issue 'for RECORD chore.
+NO AGENT SHALL SKIP STAGE PLANNING 'for RECORD issue.
+</trl>
+
+| Path | Trigger | Flow |
+|------|---------|------|
+| **CHORE** | You know exactly what to do | Branch → do it → PR → human merges |
+| **ISSUE** | Something is unknown | Issue → AAA → PLANNING → HITM → EXECUTION → PR → human merges |
+
+When in doubt, start as a chore. If unknowns emerge, upgrade to an issue.
+
+---
+
+## PLANNING Cycle (phases 1-5)
+
+<trl>
+PARTY human SHALL DEFINE PHASE vision.
+AGENT SHALL EXECUTE PHASE feasibility THEN PHASE specifications THEN PHASE architecture.
+PHASE specifications SHALL CONTAIN RECORD audit_criteria.
+PHASE architecture SHALL CONTAIN RECORD coding_plan.
+PARTY human SHALL APPROVE PHASE validation.
+NO AGENT SHALL EXECUTE STAGE EXECUTION UNLESS PARTY human APPROVE PHASE validation.
+</trl>
+
+| # | Phase | Who | Output |
+|---|-------|-----|--------|
+| 1 | **VISION** | Human | Problem + success criteria |
+| 2 | **FEASIBILITY** | Agent | GO/NO-GO + risks |
+| 3 | **SPECIFICATIONS** | Agent | Requirements + **audit criteria for Phase 8** |
+| 4 | **ARCHITECTURE** | Agent | Design + ADRs + **coding plan** |
+| 5 | **VALIDATION** | **Human approves** | Plan is complete → proceed to coding |
+
+**Phase 3 defines the audit. Phase 8 executes against it.** The plan defines what "done" looks like before any code is written.
+
+### Phase 1: VISION
+
+<trl>
+PARTY human SHALL WRITE PHASE vision 'in RECORD english.
+PHASE vision SHALL CONTAIN RECORD problem AND RECORD success_criteria.
+AGENT SHALL_NOT MODIFY PHASE vision.
+AGENT SHALL READ PHASE vision THEN EXECUTE PHASE feasibility.
+</trl>
+
+The human states what they want in plain English. This is the only phase that does not use TRL — the human speaks naturally.
+
+### Phase 2: FEASIBILITY
+
+<trl>
+AGENT SHALL ASSESS PHASE vision 'for RECORD technical_feasibility.
+AGENT SHALL IDENTIFY ALL RECORD risk.
+AGENT SHALL WRITE RECORD decision AS "GO" OR "NO-GO".
+IF RECORD decision EQUALS "NO-GO" THEN AGENT SHALL WRITE RECORD alternative.
+</trl>
+
+Quick assessment. Can we build this? What are the risks? GO or NO-GO. If NO-GO, propose an alternative.
+
+### Phase 3: SPECIFICATIONS
+
+<trl>
+AGENT SHALL WRITE ALL RECORD requirement SUBJECT_TO PHASE vision.
+AGENT SHALL WRITE RECORD audit_criteria 'for PHASE audit.
+EACH RECORD requirement SHALL 'be WRITTEN AS RECORD trl_block.
+EACH RECORD audit_criteria SHALL REFERENCE A RECORD requirement.
+NO AGENT SHALL PROCEED TO PHASE architecture WITHOUT RECORD audit_criteria.
+</trl>
+
+Requirements in TRL. Every requirement gets audit criteria — specific, testable statements that Phase 8 will check against. If you can't write audit criteria for a requirement, the requirement isn't specific enough.
+
+### Phase 4: ARCHITECTURE
+
+<trl>
+AGENT SHALL WRITE RECORD design SUBJECT_TO PHASE specifications.
+AGENT SHALL WRITE RECORD coding_plan.
+RECORD coding_plan SHALL CONTAIN RECORD file_list AND RECORD execution_order AND RECORD test_strategy.
+AGENT MAY WRITE RECORD adr 'for EACH RECORD design_decision.
+NO AGENT SHALL PROCEED TO PHASE validation WITHOUT RECORD coding_plan.
+</trl>
+
+System design plus a concrete coding plan. The coding plan lists files to create/modify, execution order, and test strategy. ADRs document non-obvious design decisions.
+
+### Phase 5: VALIDATION (HITM Gate)
+
+<trl>
+AGENT SHALL VALIDATE PHASE specifications SUBJECT_TO PHASE vision.
+AGENT SHALL VALIDATE PHASE architecture SUBJECT_TO PHASE specifications.
+AGENT SHALL ASSERT PHASE specifications CONTAINS RECORD audit_criteria.
+AGENT SHALL ASSERT PHASE architecture CONTAINS RECORD coding_plan.
+AGENT SHALL ASSERT RECORD audit_criteria REFERENCES PHASE specifications.
+NO AGENT SHALL PROCEED UNLESS ALL VALIDATION 'is VALID.
+PARTY human SHALL APPROVE PHASE validation 'before STAGE EXECUTION.
+</trl>
+
+Validation checks:
+- **Alignment:** vision → specs → architecture consistent?
+- **Completeness:** enough detail to code?
+- **Feasibility:** technology choices verified?
+- **Risk:** risks identified and mitigated?
+- **Scope:** architecture delivers specs, no more no less?
+- **Audit criteria:** defined in Phase 3, referencing specs?
+- **Coding plan:** files, order, tests defined in Phase 4?
+
+The agent runs these checks and presents results. The human approves before any coding begins.
+
+---
+
+## EXECUTION Cycle (phases 6-9)
+
+<trl>
+AGENT SHALL EXECUTE PHASE coding SUBJECT_TO RECORD coding_plan.
+AGENT SHALL EXECUTE PHASE testing THEN PHASE audit.
+PHASE audit SHALL VALIDATE RESULT SUBJECT_TO RECORD audit_criteria FROM PHASE specifications.
+IF PHASE audit 'is INVALID THEN AGENT SHALL FIX CODE THEN EXECUTE PHASE testing THEN EXECUTE PHASE audit.
+EACH PHASE audit ROUND SHALL FIX ALL RECORD finding AND WRITE RECORD test 'for EACH RECORD finding.
+NO AGENT SHALL EXECUTE PHASE deployment UNLESS PHASE audit 'is VALID.
+PARTY human SHALL APPROVE PHASE deployment.
+</trl>
+
+| # | Phase | Who | Output |
+|---|-------|-----|--------|
+| 6 | **CODING** | Agent | Working code per coding plan |
+| 7 | **TESTING** | Agent | All tests pass |
+| 8 | **AUDIT** | Agent + **Human approves** | Check against Phase 3 criteria. Cycles until clean. |
+| 9 | **DEPLOYMENT** | Agent creates PR. **Human merges.** | Shipped |
+
+### Phase 6: CODING
+
+<trl>
+AGENT SHALL IMPLEMENT CODE SUBJECT_TO RECORD coding_plan FROM PHASE architecture.
+AGENT SHALL CREATE BRANCH 'before WRITE CODE.
+AGENT SHALL FOLLOW RECORD execution_order FROM RECORD coding_plan.
+AGENT SHALL_NOT ADD RECORD feature NOT 'in PHASE specifications.
+</trl>
+
+Follow the coding plan. Don't add features that weren't specified. Don't improve code that wasn't in scope.
+
+### Phase 7: TESTING
+
+<trl>
+AGENT SHALL WRITE RECORD test 'for EACH RECORD requirement FROM PHASE specifications.
+AGENT SHALL EXECUTE ALL RECORD test.
+IF RECORD test FAIL THEN AGENT SHALL FIX CODE THEN EXECUTE RECORD test.
+NO AGENT SHALL PROCEED TO PHASE audit UNLESS ALL RECORD test PASS.
+</trl>
+
+Write tests that cover the specs. Run them. Fix failures. All tests must pass before audit.
+
+### Phase 8: AUDIT (HITM Gate)
+
+<trl>
+AGENT SHALL CHECK EACH RECORD audit_criteria FROM PHASE specifications.
+IF RECORD finding 'is CRITICAL OR HIGH THEN AGENT SHALL FIX RECORD finding.
+EACH RECORD fix SHALL INCLUDE RECORD test 'for RECORD finding.
+AGENT SHALL EXECUTE PHASE testing AFTER EACH RECORD fix.
+AGENT SHALL REPEAT PHASE audit UNTIL NO CRITICAL OR HIGH RECORD finding EXISTS.
+PARTY human SHALL REVIEW PHASE audit RESULT.
+</trl>
+
+Check every audit criterion from Phase 3. For each finding: fix it AND write a test for it. Re-run the full test suite. Repeat until clean. The human reviews the final audit result.
+
+### Phase 9: DEPLOYMENT
+
+<trl>
+AGENT SHALL CREATE RECORD pull_request 'with RECORD summary 'of ALL PHASE.
+AGENT SHALL RETURN RECORD url 'of RECORD pull_request TO PARTY human.
+AGENT SHALL STOP.
+PARTY human SHALL MERGE RECORD pull_request.
+NO AGENT SHALL MERGE RECORD pull_request.
+</trl>
+
+Create the PR. Return the URL. Stop. The human merges.
+
+---
+
+## Hard Rules
+
+<trl>
+NO AGENT SHALL COMMIT TO BRANCH main.
+NO AGENT SHALL MERGE RECORD pull_request.
+AGENT SHALL CREATE BRANCH THEN CREATE RECORD pull_request THEN STOP.
+PARTY human SHALL MERGE RECORD pull_request.
+NO AGENT SHALL EXECUTE PHASE coding UNLESS PHASE validation 'is VALID.
+NO AGENT SHALL EXECUTE PHASE deployment UNLESS PHASE audit 'is VALID.
+</trl>
+
+These are not guidelines. They are prohibitions. Violating them is a system failure.
+
+---
+
+## AAA Document Format
+
+An AAA document is a single markdown file with 9 sections, one per phase. Phase 1 is English. Phases 2-9 use TRL for specifications, criteria, and rules.
+
+See [EXAMPLE_email_mcp.md](EXAMPLE_email_mcp.md) for a complete AAA from building an email MCP server — all 9 phases, TRL specs, audit criteria, and coding plan.

--- a/installers/pip/src/trugs_agent/templates/AAA/EXAMPLE_email_mcp.md
+++ b/installers/pip/src/trugs_agent/templates/AAA/EXAMPLE_email_mcp.md
@@ -1,0 +1,184 @@
+# AAA: Email MCP — Local Email Management for Claude Code
+
+Issue: #1261
+
+## Phase 1: VISION
+
+I hate email. I have 3 Gmail accounts with 15,000+ messages across them. I need Claude Code to read, send, search, and organize email for me — triage inboxes, draft responses, archive junk, send outreach. Everything stays on my machine. No cloud OAuth, no API tokens, no Google dependency. Direct IMAP/SMTP.
+
+## Phase 2: FEASIBILITY
+
+<trl>
+SERVICE email_mcp SHALL DEPEND_ON MODULE imaplib FROM NAMESPACE python_stdlib.
+SERVICE email_mcp SHALL DEPEND_ON MODULE smtplib FROM NAMESPACE python_stdlib.
+SERVICE email_mcp SHALL REQUIRE NO EXTERNAL RESOURCE.
+SERVICE email_mcp SHALL IMPLEMENT INTERFACE mcp_stdio AS MODULE browser_mcp IMPLEMENTS INTERFACE mcp_stdio.
+</trl>
+
+**Decision:** GO. Python imaplib/smtplib are stdlib — zero external dependencies. IMAP is universal (Google Workspace, Proton Bridge, any provider). MCP stdio transport matches existing browser_mcp.py and gimp_mcp.py pattern.
+
+### Risks
+
+<trl>
+IF DATA credential ROUTE TO FILE repository THEN THROW EXCEPTION security_violation.
+AGENT SHALL READ DATA credential FROM ENDPOINT environment_variable.
+FILE email_accounts.json SHALL REQUIRE PRIVATE ACCESS.
+</trl>
+
+<trl>
+IF AGENT DELETE ALL MESSAGE WITHOUT VALID RECORD confirm THEN THROW EXCEPTION data_loss.
+FUNCTION email_delete SHALL REQUIRE ACTIVE RECORD confirm 'before DELETE MESSAGE.
+FUNCTION email_delete SHALL DEFAULT TO RECORD dry_run.
+</trl>
+
+## Phase 3: SPECIFICATIONS
+
+### Tools
+
+<trl>
+DEFINE "read_tools" AS STAGE CONTAINS FUNCTION email_accounts AND FUNCTION email_folders AND FUNCTION email_list AND FUNCTION email_read.
+DEFINE "search_tools" AS STAGE CONTAINS FUNCTION email_search.
+DEFINE "write_tools" AS STAGE CONTAINS FUNCTION email_send AND FUNCTION email_reply AND FUNCTION email_draft.
+DEFINE "organize_tools" AS STAGE CONTAINS FUNCTION email_move AND FUNCTION email_delete AND FUNCTION email_flag.
+SERVICE email_mcp CONTAINS STAGE read_tools AND STAGE search_tools AND STAGE write_tools AND STAGE organize_tools.
+</trl>
+
+### Tool Specifications
+
+<trl>
+FUNCTION email_accounts SHALL READ ALL ENDPOINT imap_account FROM FILE accounts.json THEN WRITE RESULT TO PARTY caller.
+FUNCTION email_folders SHALL READ ALL MODULE folder FROM ENDPOINT imap_account THEN WRITE RESULT TO PARTY caller.
+FUNCTION email_list SHALL FILTER ALL MESSAGE BY MODULE folder AND OPTIONAL ACTIVE state THEN SORT RESULT BY DATA date THEN WRITE RESULT TO PARTY caller.
+FUNCTION email_read SHALL READ A MESSAGE BY DATA uid FROM MODULE folder THEN WRITE RESULT TO PARTY caller.
+FUNCTION email_search SHALL FILTER ALL MESSAGE BY DATA from_addr OR DATA subject OR DATA date OR DATA body THEN WRITE RESULT TO PARTY caller.
+FUNCTION email_send SHALL WRITE MESSAGE TO ENDPOINT smtp THEN SEND MESSAGE TO PARTY recipient.
+FUNCTION email_reply SHALL READ MESSAGE BY DATA uid THEN WRITE MESSAGE TO ENDPOINT smtp THEN SEND MESSAGE TO PARTY original_sender.
+FUNCTION email_draft SHALL WRITE MESSAGE TO MODULE drafts_folder.
+FUNCTION email_move SHALL READ MESSAGE BY DATA uid FROM MODULE source_folder THEN WRITE MESSAGE TO MODULE target_folder THEN DELETE MESSAGE FROM MODULE source_folder.
+FUNCTION email_delete SHALL VALIDATE ACTIVE RECORD confirm THEN DELETE MESSAGE OR WRITE RECORD dry_run TO PARTY caller.
+FUNCTION email_flag SHALL WRITE DATA flag TO MESSAGE BY DATA uid.
+</trl>
+
+### Configuration
+
+<trl>
+FILE email_accounts.json SHALL PERSIST 'at ENDPOINT ~/.config/trugs/.
+FILE email_accounts.json SHALL REQUIRE PRIVATE ACCESS.
+EACH ENDPOINT imap_account SHALL CONTAIN DATA email AND DATA imap_host AND DATA imap_port AND DATA smtp_host AND DATA smtp_port AND DATA password_env.
+NO FILE SHALL CONTAIN DATA password DIRECTLY.
+EACH DATA password SHALL READ FROM ENDPOINT environment_variable.
+</trl>
+
+### Audit Criteria (Phase 8 checks against these)
+
+<trl>
+FUNCTION email_list SHALL RETURN VALID RESULT 'for EACH ENDPOINT imap_account.
+FUNCTION email_read SHALL RETURN DATA body_text AND DATA headers 'for ANY MESSAGE.
+FUNCTION email_send SHALL SEND MESSAGE THEN RETURN DATA message_id.
+FUNCTION email_search SHALL FILTER BY DATA from_addr AND DATA subject AND DATA date.
+FUNCTION email_delete 'with NO RECORD confirm SHALL RETURN RECORD dry_run.
+FUNCTION email_delete 'with ACTIVE RECORD confirm SHALL DELETE MESSAGE.
+NO FUNCTION SHALL WRITE DATA credential TO STREAM log OR FILE.
+ALL FUNCTION SHALL RETURN VALID DATA json.
+SERVICE email_mcp SHALL REQUIRE NO EXTERNAL RESOURCE EXCEPT MODULE python_stdlib.
+</trl>
+
+## Phase 4: ARCHITECTURE
+
+### Decisions
+
+<trl>
+SERVICE email_mcp SHALL USE MODULE imaplib DIRECTLY.
+SERVICE email_mcp SHALL_NOT USE SERVICE thunderbird_api.
+SERVICE email_mcp SHALL PERSIST AS FILE email_mcp.py 'at ENDPOINT TRUGS_WEB/trugs_web/.
+</trl>
+
+**ADR-1261-01:** Direct IMAP/SMTP over Thunderbird WebExtension API. Zero dependencies, works without Thunderbird running, universal across providers.
+
+<trl>
+FILE email_accounts.json SHALL PERSIST 'at ENDPOINT ~/.config/trugs/.
+FILE email_accounts.json SHALL_NOT PERSIST 'at ENDPOINT repository.
+FILE .env SHALL CONTAIN ALL DATA password_env.
+FILE .env SHALL REQUIRE PRIVATE ACCESS.
+</trl>
+
+**ADR-1261-02:** Config in ~/.config/trugs/, not in repo. Credentials via environment variables. Never in the JSON file.
+
+<trl>
+FUNCTION email_delete SHALL DEFAULT TO RECORD dry_run.
+FUNCTION email_delete SHALL REQUIRE EXPLICIT ACTIVE RECORD confirm TO DELETE.
+FUNCTION email_move SHALL REQUIRE DATA target_folder.
+</trl>
+
+**ADR-1261-03:** Destructive operations require explicit confirmation. Default is dry-run.
+
+### Coding Plan
+
+<trl>
+AGENT SHALL CREATE FILE email_mcp.py 'at ENDPOINT TRUGS_WEB/trugs_web/.
+AGENT SHALL IMPLEMENT STAGE read_tools THEN STAGE write_tools THEN STAGE search_tools THEN STAGE organize_tools.
+AGENT SHALL IMPLEMENT FUNCTION config_loader THEN FUNCTION imap_connect THEN FUNCTION smtp_connect.
+AGENT SHALL IMPLEMENT FUNCTION mcp_wrapper FINALLY.
+AGENT SHALL WRITE RECORD test 'for EACH FUNCTION.
+</trl>
+
+## Phase 5: VALIDATION
+
+**HITM Gate — Human approves before coding.**
+
+- [x] Vision → specs → architecture consistent
+- [x] Enough detail to code (12 tools specified)
+- [x] Technology verified (imaplib/smtplib stdlib)
+- [x] Risks mitigated (credentials via env vars, dry-run deletes)
+- [x] Audit criteria defined in Phase 3
+- [x] Coding plan defined in Phase 4
+
+**APPROVED — proceed to execution.**
+
+---
+
+## Phase 6: CODING
+
+Status: COMPLETE
+
+<trl>
+AGENT SHALL IMPLEMENT SERVICE email_mcp SUBJECT_TO RECORD coding_plan.
+</trl>
+
+12 tools implemented in `TRUGS_WEB/trugs_web/email_mcp.py`. Three accounts tested (admin@trugs.ai, xepayacllc@gmail.com, xepayac@gmail.com).
+
+## Phase 7: TESTING
+
+Status: COMPLETE
+
+<trl>
+AGENT SHALL VALIDATE SERVICE email_mcp SUBJECT_TO RECORD audit_criteria.
+</trl>
+
+- email_accounts: returns all configured accounts
+- email_list: returns messages from all 3 accounts
+- email_read: returns full message body and headers
+- email_search: filters by sender, subject, date
+- email_send: sent endorsement emails to 3 professors
+- email_delete: dry-run confirmed, then executed (5,063 archived)
+- email_folders: fixed IMAP LIST parsing, returns folder names + counts
+
+## Phase 8: AUDIT
+
+Status: IN PROGRESS
+
+Checking against Phase 3 audit criteria:
+
+- [x] email_list returns valid results for each account
+- [x] email_read returns body_text and headers
+- [x] email_send sends and returns message_id
+- [x] email_search filters by from, subject, date
+- [x] email_delete without confirm returns dry_run
+- [x] email_delete with confirm deletes
+- [x] No credentials in logs or files
+- [x] All functions return valid JSON
+- [x] Zero external dependencies
+
+## Phase 9: DEPLOYMENT
+
+Status: PR #1263 created. Human merges.

--- a/installers/pip/src/trugs_agent/templates/AAA/README.md
+++ b/installers/pip/src/trugs_agent/templates/AAA/README.md
@@ -1,0 +1,34 @@
+# AAA — 9-Phase Development Protocol
+
+AAA is a development workflow that forces your LLM to plan before it codes, define "done" before it builds, and never ship without your approval.
+
+## When to Use
+
+Any time your LLM needs to build something non-trivial. If the task has unknowns, needs design decisions, or touches multiple files — use AAA.
+
+For simple, known tasks (fix a typo, rename a variable), skip AAA entirely and use a CHORE: branch, do it, PR, merge.
+
+## How It Works
+
+**Two cycles, three human touchpoints:**
+
+```
+PLANNING: VISION → FEASIBILITY → SPECIFICATIONS → ARCHITECTURE → VALIDATION (human approves)
+EXECUTION: CODING → TESTING → AUDIT → DEPLOYMENT (human merges)
+```
+
+1. **You** state what you want (VISION)
+2. **Agent** plans it (phases 2-4), including audit criteria in phase 3
+3. **You** approve the plan (VALIDATION)
+4. **Agent** builds and tests it (phases 6-8), auditing against phase 3 criteria
+5. **You** merge the PR (DEPLOYMENT)
+
+The agent never codes without an approved plan. Never ships without your review.
+
+## Key Rule
+
+Phase 3 (SPECIFICATIONS) defines the audit criteria. Phase 8 (AUDIT) checks against them. The plan defines what "done" looks like before any code is written.
+
+## Example
+
+See [EXAMPLE_email_mcp.md](EXAMPLE_email_mcp.md) — a real AAA plan from building an email MCP server. All 9 phases, TRL specs, audit criteria, and coding plan.

--- a/installers/pip/src/trugs_agent/templates/AGENT.md
+++ b/installers/pip/src/trugs_agent/templates/AGENT.md
@@ -1,0 +1,309 @@
+# TRUGS Agent System
+
+<trl>
+DEFINE "TRUGS" AS NAMESPACE.
+DEFINE "TRL" AS INTERFACE.
+NAMESPACE TRUGS GOVERNS ALL DATA graph AND ALL RECORD sentence.
+INTERFACE TRL GOVERNS ALL RECORD sentence.
+AGENT SHALL READ THIS FILE THEN IMPLEMENT ALL RECORD instruction.
+</trl>
+
+You are an agent that speaks TRL. This file teaches the language. Component folders teach the methodology.
+
+| Component | What it teaches | File |
+|-----------|----------------|------|
+| **Folder** | Machine-readable filesystem index | `FOLDER/AGENT.md` |
+| **AAA** | 9-phase development protocol | `AAA/AGENT.md` |
+| **EPIC** | Portfolio tracking as a graph | `EPIC/AGENT.md` |
+| **Memory** | Persistent context across sessions | `MEMORY/AGENT.md` |
+| **Trugging** | Describing a codebase with TRUGs and TRL | `TRUGGING/AGENT.md` |
+| **Web Hub** | Curated web resource landscape | `WEB_HUB/AGENT.md` |
+| **Skills** | Composable agent actions — primitives and compounds | `SKILLS/AGENT.md` |
+
+Read this file first. Read component files when you need that component.
+
+---
+
+## TRL vs TRUGS — When to Use Which
+
+<trl>
+DEFINE "TRL" AS INTERFACE 'for RECORD sentence.
+DEFINE "TRUGS" AS INTERFACE 'for DATA graph.
+EACH RECORD sentence SHALL COMPILE TO DATA graph.
+EACH DATA graph SHALL COMPILE TO RECORD sentence.
+</trl>
+
+**TRL (sentences)** — use when communicating. Instructions, specifications, acceptance criteria, code comments. Human writes it, agent reads it, both understand it.
+
+**TRUGS (graphs)** — use when storing and executing. Project tracking, validation, traversal, state management. Machines read it, tools validate it, agents navigate it.
+
+| Situation | Use | Why |
+|-----------|-----|-----|
+| Writing instructions | TRL | Human-readable, agent-executable |
+| Code comments | TRL | Compilable documentation |
+| Acceptance criteria | TRL | Both human and agent verify against it |
+| Project tracking | TRUGS | Machines traverse and validate |
+| Development phases | TRL | Communication between human and agent |
+| Execution state | TRUGS | Agent tracks progress as graph nodes |
+| Memory files | English + TRL | Context for future sessions |
+| Validation rules | TRUGS | Tools enforce mechanically |
+
+The sentence is the graph. The graph is the sentence. TRL is how you talk about it. TRUGS is how you store it.
+
+### Side-by-Side Example
+
+**TRL (the sentence):**
+
+```
+<trl>
+SERVICE api SHALL AUTHENTICATE PARTY user
+  THEN READ DATA FROM STREAM database
+  THEN WRITE RESULT TO PARTY user
+  OR THROW EXCEPTION.
+IF SERVICE api THROW EXCEPTION
+  THEN SERVICE api SHALL SEND ERROR TO PARTY user.
+</trl>
+```
+
+**TRUGS (the graph):**
+
+```json
+{
+  "nodes": [
+    {"id": "api", "type": "SERVICE", "properties": {"name": "api"}, "parent_id": null, "contains": [], "metric_level": "BASE_SERVICE", "dimension": "system"},
+    {"id": "user", "type": "PARTY", "properties": {"name": "user"}, "parent_id": null, "contains": [], "metric_level": "BASE_PARTY", "dimension": "system"},
+    {"id": "database", "type": "STREAM", "properties": {"name": "database"}, "parent_id": null, "contains": [], "metric_level": "BASE_STREAM", "dimension": "system"},
+    {"id": "op_auth", "type": "FUNCTION", "properties": {"operation": "AUTHENTICATE", "modal": "SHALL"}, "parent_id": "api", "contains": [], "metric_level": "CENTI_FUNCTION", "dimension": "system"},
+    {"id": "op_read", "type": "FUNCTION", "properties": {"operation": "READ"}, "parent_id": "api", "contains": [], "metric_level": "CENTI_FUNCTION", "dimension": "system"},
+    {"id": "op_write", "type": "FUNCTION", "properties": {"operation": "WRITE"}, "parent_id": "api", "contains": [], "metric_level": "CENTI_FUNCTION", "dimension": "system"},
+    {"id": "op_throw", "type": "EXCEPTION", "properties": {"operation": "THROW"}, "parent_id": "api", "contains": [], "metric_level": "CENTI_EXCEPTION", "dimension": "system"},
+    {"id": "op_send_error", "type": "FUNCTION", "properties": {"operation": "SEND", "object": "ERROR"}, "parent_id": "api", "contains": [], "metric_level": "CENTI_FUNCTION", "dimension": "system"}
+  ],
+  "edges": [
+    {"from_id": "op_auth", "to_id": "user", "relation": "AUTHENTICATE"},
+    {"from_id": "op_auth", "to_id": "op_read", "relation": "THEN"},
+    {"from_id": "op_read", "to_id": "database", "relation": "FROM"},
+    {"from_id": "op_read", "to_id": "op_write", "relation": "THEN"},
+    {"from_id": "op_write", "to_id": "user", "relation": "TO"},
+    {"from_id": "op_write", "to_id": "op_throw", "relation": "OR"},
+    {"from_id": "op_throw", "to_id": "op_send_error", "relation": "THEN"},
+    {"from_id": "op_send_error", "to_id": "user", "relation": "TO"}
+  ]
+}
+```
+
+Same specification. Same structure. Different views.
+
+---
+
+## TRL — The Language
+
+<trl>
+DEFINE "TRL" AS INTERFACE.
+INTERFACE TRL CONTAINS 190 UNIQUE RECORD word.
+EACH RECORD word BELONGS_TO EXACTLY A RECORD part_of_speech.
+EACH RECORD sentence SHALL COMPILE TO DATA graph.
+EACH DATA graph SHALL COMPILE TO RECORD sentence.
+</trl>
+
+### Vocabulary (190 words)
+
+**Nouns — things that exist (become graph nodes)**
+
+<trl>
+DEFINE "actor" AS PARTY OR AGENT OR PROCESS OR SERVICE OR FUNCTION OR TRANSFORM OR PRINCIPAL.
+DEFINE "artifact" AS DATA OR FILE OR RECORD OR MESSAGE OR STREAM OR RESOURCE.
+DEFINE "container" AS PIPELINE OR STAGE OR MODULE OR NAMESPACE.
+DEFINE "boundary" AS ENTRY OR EXIT OR INTERFACE OR ENDPOINT.
+DEFINE "outcome" AS ERROR OR EXCEPTION OR REMEDY.
+</trl>
+
+**Verbs — actions (become operation nodes)**
+
+<trl>
+DEFINE "transform" AS FILTER OR MAP OR SORT OR MERGE OR SPLIT OR AGGREGATE OR GROUP OR DISTINCT OR TAKE OR SKIP.
+DEFINE "move" AS READ OR WRITE OR SEND OR RECEIVE OR REQUEST OR RESPOND OR AUTHENTICATE.
+DEFINE "obligate" AS VALIDATE OR ASSERT OR REQUIRE.
+DEFINE "permit" AS ALLOW OR APPROVE OR GRANT OR OVERRIDE.
+DEFINE "prohibit" AS DENY OR REJECT OR REVOKE.
+DEFINE "control" AS BRANCH OR MATCH OR RETRY OR TIMEOUT OR THROW OR EXISTS OR EXPIRE OR EQUALS OR EXCEEDS.
+DEFINE "bind" AS DEFINE OR DECLARE OR IMPLEMENT OR NEST OR AUGMENT OR REPLACE OR CITE OR ADMINISTER.
+DEFINE "resolve" AS CATCH OR HANDLE OR RECOVER.
+</trl>
+
+**Modals — obligation (modify verbs)**
+
+<trl>
+DEFINE "SHALL" AS REQUIRED RECORD obligation.
+DEFINE "MAY" AS OPTIONAL RECORD permission.
+DEFINE "SHALL_NOT" AS REQUIRED RECORD prohibition.
+EACH RECORD obligation SHALL REQUIRE PARTY AS RECORD subject.
+NO DATA SHALL RECEIVE RECORD obligation.
+NO RECORD SHALL RECEIVE RECORD obligation UNLESS RECORD 'is PARTY.
+</trl>
+
+- SHALL = MUST do this. Failure is a violation.
+- MAY = ALLOWED but not required.
+- SHALL_NOT = MUST NOT do this. Doing it is a violation.
+
+**Adjectives — modify nouns (become node properties)**
+
+<trl>
+DEFINE "type" AS STRING OR INTEGER OR BOOLEAN OR ARRAY OR OBJECT.
+DEFINE "access" AS PUBLIC OR PRIVATE OR CONFIDENTIAL OR READONLY.
+DEFINE "state" AS VALID OR INVALID OR ACTIVE OR PENDING OR FAILED OR MUTABLE OR IMMUTABLE.
+DEFINE "quantity" AS REQUIRED OR OPTIONAL OR UNIQUE OR MULTIPLE.
+DEFINE "priority" AS CRITICAL OR HIGH OR LOW OR DEFAULT.
+</trl>
+
+**Adverbs — modify verbs (become operation properties)**
+
+<trl>
+DEFINE "timing" AS ASYNC OR SYNC OR PARALLEL OR SEQUENTIAL OR IMMEDIATE OR WITHIN.
+DEFINE "repetition" AS ONCE OR ALWAYS OR NEVER OR BOUNDED.
+DEFINE "degree" AS STRICTLY OR SUBSTANTIALLY OR REASONABLY.
+</trl>
+
+**Prepositions — relationships (become graph edges)**
+
+<trl>
+DEFINE "flow" AS FEEDS OR ROUTES OR TO OR FROM OR RETURNS_TO.
+DEFINE "dependency" AS BINDS OR DEPENDS_ON OR IMPLEMENTS OR EXTENDS OR SUBJECT_TO.
+DEFINE "authority" AS GOVERNS OR PURSUANT_TO OR ON_BEHALF_OF.
+DEFINE "structure" AS CONTAINS OR REFERENCES OR SUPERSEDES.
+DEFINE "binding" AS AS OR BY.
+</trl>
+
+**Conjunctions — connect clauses (become structural edges)**
+
+<trl>
+DEFINE "sequence" AS THEN OR FINALLY.
+DEFINE "parallel" AS AND.
+DEFINE "alternative" AS OR OR ELSE.
+DEFINE "conditional" AS IF OR WHEN OR WHILE.
+DEFINE "exception" AS UNLESS OR EXCEPT OR NOTWITHSTANDING OR PROVIDED_THAT OR WHEREAS.
+</trl>
+
+**Articles** — ALL, EACH, EVERY, ANY, SOME, A, THE, THIS, NO, NONE
+
+**Pronouns** — SELF, RESULT, OUTPUT, INPUT, SOURCE, TARGET
+
+**Sugar** — OF, IS, ARE, BE, BEEN, HAS, HAVE, WILL, THAT, WHICH, WHERE, WHO, INTO, UPON, WITH, FOR, AT, ON, PLEASE, ALSO, THEN_ALSO, THESE, THOSE, SUCH (compile to nothing — human readability only)
+
+### How to Read and Execute
+
+<trl>
+AGENT SHALL STRIP ALL RECORD sugar FROM RECORD sentence.
+AGENT SHALL PARSE RECORD sentence AS RECORD subject THEN RECORD modal THEN RECORD verb THEN RECORD object.
+IF RECORD modal EQUALS "SHALL" THEN AGENT SHALL EXECUTE RECORD verb STRICTLY.
+IF RECORD modal EQUALS "MAY" THEN AGENT MAY EXECUTE RECORD verb.
+IF RECORD modal EQUALS "SHALL_NOT" THEN AGENT SHALL_NOT EXECUTE RECORD verb.
+AGENT SHALL FOLLOW RECORD conjunction AS RECORD sequence.
+</trl>
+
+Parse example:
+```
+PARTY system SHALL FILTER ALL ACTIVE RECORD THEN WRITE RESULT TO ENDPOINT output.
+```
+- PARTY system → Actor node (subject)
+- SHALL → obligation
+- FILTER → Transform operation
+- ALL ACTIVE RECORD → scoped, qualified artifact
+- THEN → sequential conjunction
+- WRITE RESULT TO ENDPOINT output → Move operation with destination
+
+### Key Rules
+
+<trl>
+EACH RECORD word SHALL BELONG_TO EXACTLY A RECORD part_of_speech.
+EACH RECORD modal SHALL REQUIRE PARTY AS RECORD subject.
+EACH RECORD pronoun SHALL RESOLVE WITHIN THIS RECORD sentence.
+NO RECORD sentence SHALL CONTAIN "NO" AND "SHALL_NOT" 'in SAME RECORD clause.
+AGENT SHALL STRIP RECORD sugar 'before PARSE RECORD sentence.
+</trl>
+
+---
+
+## Using TRL in Your Project
+
+<trl>
+PARTY human MAY WRITE RECORD trl_block 'in FILE code_comment OR FILE specification OR FILE issue OR FILE config.
+AGENT SHALL READ RECORD trl_block THEN COMPILE TO DATA graph THEN EXECUTE.
+</trl>
+
+### In code comments
+
+```python
+# <trl>FUNCTION validate SHALL VALIDATE ALL REQUIRED RECORD
+#   SUBJECT_TO INTERFACE schema.
+# IF FUNCTION validate THROW EXCEPTION
+#   THEN SEND ERROR TO PARTY caller.</trl>
+def validate(records, schema):
+    for record in records:
+        if not schema.validate(record):
+            raise ValidationError(record.id)
+```
+
+### In specifications
+
+```markdown
+<trl>
+SERVICE api SHALL RESPOND WITHIN 200ms.
+SERVICE api SHALL AUTHENTICATE ALL PARTY 'before READ DATA.
+NO SERVICE api SHALL WRITE INVALID RECORD TO STREAM database.
+SERVICE api SHALL RETRY BOUNDED 3 WITHIN 30s OR THROW EXCEPTION.
+</trl>
+```
+
+### In issue descriptions
+
+```markdown
+<trl>
+AGENT SHALL CREATE MODULE email_mcp CONTAINS FUNCTION send AND FUNCTION read AND FUNCTION search.
+EACH FUNCTION SHALL READ CONFIG FROM FILE accounts.json.
+FUNCTION delete SHALL REQUIRE VALID CONFIRM 'before DELETE RECORD.
+NO FUNCTION SHALL WRITE RECORD password TO FILE OR STREAM.
+</trl>
+```
+
+---
+
+## The Validator
+
+TRUGS graphs are validated by `trugs-validate` — 16 rules that every graph must pass:
+
+- **Rules 1-9 (structural)** — always enforced. Unique IDs, valid edge references, hierarchy consistency, required fields, correct types.
+- **Rules 10-16 (compositional)** — enforced when graph declares `core_v1.0.0`. Subject-operation compatibility, modifier-entity compatibility, no double negation, reference scope.
+
+```bash
+python tools/validate.py my_graph.trug.json       # Validate one
+python tools/validate.py --all my_project/         # Validate all
+```
+
+<trl>
+AGENT SHALL VALIDATE ALL DATA graph SUBJECT_TO INTERFACE core_v1.0.0.
+IF DATA graph 'is INVALID THEN AGENT SHALL FIX DATA graph THEN VALIDATE DATA graph.
+NO AGENT SHALL DEPLOY INVALID DATA graph.
+</trl>
+
+---
+
+## Quick Reference
+
+<trl>
+INTERFACE TRL CONTAINS 190 UNIQUE RECORD word.
+EACH RECORD word SHALL 'have EXACTLY A RECORD meaning.
+NO AGENT SHALL COMMIT TO BRANCH main.
+NO AGENT SHALL MERGE RECORD pull_request.
+</trl>
+
+For component-specific instructions, read the AGENT.md in each folder:
+- **FOLDER/AGENT.md** — filesystem indexing
+- **AAA/AGENT.md** — development protocol
+- **EPIC/AGENT.md** — portfolio tracking
+- **MEMORY/AGENT.md** — persistent context
+- **TRUGGING/AGENT.md** — codebase description
+- **WEB_HUB/AGENT.md** — curated web resource landscape
+- **SKILLS/AGENT.md** — composable agent actions (19 primitives, compound composition)
+
+For the full TRL specification: https://github.com/TRUGS-LLC/TRUGS

--- a/installers/pip/src/trugs_agent/templates/EPIC/AGENT.md
+++ b/installers/pip/src/trugs_agent/templates/EPIC/AGENT.md
@@ -1,0 +1,139 @@
+# EPIC — Agent Instructions
+
+<trl>
+DEFINE "EPIC" AS DATA graph 'for RECORD project_tracking.
+DATA graph EPIC CONTAINS DATA node 'of TYPE TRACKER AND TYPE EPIC AND TYPE TASK.
+DATA graph EPIC CONTAINS DATA edge 'of RELATION BLOCKS AND RELATION DEPENDS_ON AND RELATION IMPLEMENTS.
+AGENT SHALL READ DATA graph EPIC 'at ENTRY RECORD session.
+AGENT SHALL UPDATE DATA graph EPIC WHEN RECORD status CHANGES.
+</trl>
+
+An EPIC is a TRUG graph that tracks your portfolio — projects, tasks, dependencies, and status. You read it to know what exists, what's in progress, what's blocked, and what to work on next.
+
+---
+
+## Structure
+
+<trl>
+DEFINE "TRACKER" AS DATA node 'at KILO METRIC_LEVEL.
+DEFINE "EPIC" AS DATA node 'at HECTO METRIC_LEVEL.
+DEFINE "TASK" AS DATA node 'at BASE METRIC_LEVEL.
+TRACKER CONTAINS EPIC.
+EPIC CONTAINS TASK.
+EACH TASK SHALL CONTAIN RECORD status AND RECORD priority.
+</trl>
+
+Three levels:
+
+```
+TRACKER (root — the whole portfolio)
+  └── EPIC (initiative — a body of related work)
+       └── TASK (work item — one thing to do)
+```
+
+### TRACKER Node
+
+<trl>
+EACH DATA graph EPIC SHALL CONTAIN EXACTLY A DATA node 'of TYPE TRACKER.
+TRACKER SHALL CONTAIN RECORD name AND RECORD owner AND RECORD total_open_issues AND RECORD last_updated.
+TRACKER SHALL CONTAIN RECORD present_plan 'with RECORD summary AND RECORD active_issues.
+</trl>
+
+The root node. One per project. Contains the current focus and open issue count. This is the first thing you read.
+
+### EPIC Node
+
+<trl>
+EACH EPIC SHALL CONTAIN RECORD name AND RECORD purpose AND RECORD status.
+RECORD status SHALL 'be "TODO" OR "IN_PROGRESS" OR "DONE" OR "BLOCKED".
+EPIC MAY CONTAIN RECORD github_issue AND RECORD labels AND RECORD created_date.
+EACH EPIC SHALL CONTAIN ONE OR MORE TASK.
+</trl>
+
+An initiative — a group of related tasks toward a goal. Has a purpose (why it exists) and a status.
+
+### TASK Node
+
+<trl>
+EACH TASK SHALL CONTAIN RECORD name AND RECORD status AND RECORD priority.
+RECORD priority SHALL 'be "P0" OR "P1" OR "P2" OR "P3".
+TASK MAY CONTAIN RECORD github_issue AND RECORD assignee.
+</trl>
+
+A single work item. Has a priority and a status. Maps to a GitHub issue when one exists.
+
+---
+
+## Edges
+
+<trl>
+DEFINE "BLOCKS" AS DATA edge — TARGET SHALL_NOT START UNTIL SOURCE 'is DONE.
+DEFINE "DEPENDS_ON" AS DATA edge — TARGET REQUIRES SOURCE TO FUNCTION.
+DEFINE "IMPLEMENTS" AS DATA edge — TARGET DELIVERS SOURCE.
+EACH DATA edge SHALL CONTAIN RECORD from_id AND RECORD to_id AND RECORD relation.
+DATA edge MAY CONTAIN RECORD description.
+</trl>
+
+| Relation | Meaning | Example |
+|----------|---------|---------|
+| `BLOCKS` | Can't start B until A is done | "Deploy" BLOCKS "Test in production" |
+| `DEPENDS_ON` | B requires A to function | "API" DEPENDS_ON "Auth module" |
+| `IMPLEMENTS` | B delivers A | Task IMPLEMENTS Epic |
+
+---
+
+## Reading the EPIC
+
+<trl>
+AGENT SHALL READ DATA graph EPIC 'at ENTRY RECORD session.
+AGENT SHALL IDENTIFY ALL TASK 'where RECORD status EQUALS "IN_PROGRESS".
+AGENT SHALL IDENTIFY ALL TASK 'where RECORD status EQUALS "BLOCKED".
+AGENT SHALL IDENTIFY ALL DATA edge 'of RELATION BLOCKS TO UNDERSTAND RECORD dependency.
+AGENT SHALL READ RECORD present_plan FROM TRACKER TO UNDERSTAND RECORD current_focus.
+</trl>
+
+At session start, read the EPIC to answer:
+1. **What's the current focus?** → `tracker.present_plan.summary`
+2. **What's in progress?** → all tasks with status `IN_PROGRESS`
+3. **What's blocked and by what?** → follow `BLOCKS` edges
+4. **What should I work on next?** → highest priority `TODO` task that isn't blocked
+
+---
+
+## Updating the EPIC
+
+<trl>
+IF AGENT START TASK THEN AGENT SHALL SET RECORD status TO "IN_PROGRESS".
+IF AGENT COMPLETE TASK THEN AGENT SHALL SET RECORD status TO "DONE".
+IF TASK 'is BLOCKED THEN AGENT SHALL SET RECORD status TO "BLOCKED" AND CREATE DATA edge 'of RELATION BLOCKS.
+IF AGENT CREATE RECORD issue THEN AGENT SHALL CREATE TASK 'in EPIC 'with RECORD github_issue.
+AGENT SHALL UPDATE RECORD last_updated 'on TRACKER AFTER EACH CHANGE.
+AGENT SHALL UPDATE RECORD total_open_issues 'on TRACKER AFTER EACH CHANGE.
+</trl>
+
+Keep the EPIC in sync with reality:
+- Start a task → mark IN_PROGRESS
+- Finish a task → mark DONE
+- Hit a blocker → mark BLOCKED + add BLOCKS edge
+- Create a GitHub issue → add a TASK node with the issue number
+- Any change → update `last_updated` and `total_open_issues` on the tracker
+
+---
+
+## Creating an EPIC from Scratch
+
+<trl>
+AGENT SHALL SCAN NAMESPACE project 'for ALL RECORD initiative.
+'for EACH RECORD initiative AGENT SHALL CREATE DATA node 'of TYPE EPIC.
+'for EACH RECORD work_item AGENT SHALL CREATE DATA node 'of TYPE TASK.
+AGENT SHALL CREATE DATA edge 'for EACH RECORD dependency 'between TASK.
+AGENT SHALL VALIDATE DATA graph EPIC.
+</trl>
+
+1. Identify the major initiatives (epics)
+2. Break each into tasks
+3. Map dependencies as BLOCKS/DEPENDS_ON edges
+4. Set priorities and statuses
+5. Validate the graph
+
+See [EXAMPLE_project.trug.json](EXAMPLE_project.trug.json) for a starter template.

--- a/installers/pip/src/trugs_agent/templates/EPIC/EXAMPLE_project.trug.json
+++ b/installers/pip/src/trugs_agent/templates/EPIC/EXAMPLE_project.trug.json
@@ -1,0 +1,89 @@
+{
+  "name": "Project Tracker",
+  "version": "1.0.0",
+  "type": "TRACKER",
+  "description": "Portfolio tracker for your project. Tracks epics, tasks, and their relationships.",
+  "dimensions": {
+    "project_tracking": {
+      "description": "Work management: tracker > epics > tasks",
+      "base_level": "BASE"
+    }
+  },
+  "capabilities": {
+    "extensions": [],
+    "vocabularies": ["core_v1.0.0"],
+    "profiles": []
+  },
+  "nodes": [
+    {
+      "id": "tracker_root",
+      "type": "TRACKER",
+      "properties": {
+        "name": "My Project",
+        "owner": "your-name",
+        "total_open_issues": 0,
+        "last_updated": "2026-04-01",
+        "present_plan": {
+          "summary": "Describe your current focus here.",
+          "active_issues": []
+        }
+      },
+      "parent_id": null,
+      "contains": ["epic_example"],
+      "metric_level": "KILO_TRACKER",
+      "dimension": "project_tracking"
+    },
+    {
+      "id": "epic_example",
+      "type": "EPIC",
+      "properties": {
+        "name": "Example Epic — Replace With Your First Initiative",
+        "purpose": "What this epic achieves and why it matters.",
+        "status": "IN_PROGRESS",
+        "github_issue": null,
+        "labels": [],
+        "created_date": "2026-04-01"
+      },
+      "parent_id": "tracker_root",
+      "contains": ["task_example_1", "task_example_2"],
+      "metric_level": "HECTO_EPIC",
+      "dimension": "project_tracking"
+    },
+    {
+      "id": "task_example_1",
+      "type": "TASK",
+      "properties": {
+        "name": "First task — replace with real work",
+        "status": "TODO",
+        "github_issue": null,
+        "priority": "P1"
+      },
+      "parent_id": "epic_example",
+      "contains": [],
+      "metric_level": "BASE_TASK",
+      "dimension": "project_tracking"
+    },
+    {
+      "id": "task_example_2",
+      "type": "TASK",
+      "properties": {
+        "name": "Second task — depends on first",
+        "status": "TODO",
+        "github_issue": null,
+        "priority": "P2"
+      },
+      "parent_id": "epic_example",
+      "contains": [],
+      "metric_level": "BASE_TASK",
+      "dimension": "project_tracking"
+    }
+  ],
+  "edges": [
+    {
+      "from_id": "task_example_2",
+      "to_id": "task_example_1",
+      "relation": "BLOCKS",
+      "properties": {"description": "Task 2 cannot start until task 1 is complete"}
+    }
+  ]
+}

--- a/installers/pip/src/trugs_agent/templates/EPIC/README.md
+++ b/installers/pip/src/trugs_agent/templates/EPIC/README.md
@@ -1,0 +1,33 @@
+# EPIC — Portfolio Tracker
+
+An EPIC is a TRUG graph that tracks your projects, tasks, and their dependencies. Your LLM reads it to know what's in progress, what's blocked, and what to work on next.
+
+## When to Use
+
+When you have more than one initiative happening at once. The EPIC gives your LLM a bird's-eye view of all work — no more re-explaining context every session.
+
+## How It Works
+
+An EPIC is a `.trug.json` file with three levels:
+
+```
+TRACKER (root)
+  └── EPIC (initiative)
+       └── TASK (work item)
+```
+
+Edges express dependencies: `BLOCKS`, `DEPENDS_ON`, `IMPLEMENTS`.
+
+Your LLM reads the EPIC at session start to understand:
+- What projects exist and their status
+- What tasks are TODO, IN_PROGRESS, or DONE
+- What's blocked and by what
+- What the current focus is
+
+## Key Rule
+
+The EPIC is the single source of truth for project state. When your LLM needs to know "what should I work on?", it reads the EPIC — not a chat history, not a TODO list.
+
+## Example
+
+See [EXAMPLE_project.trug.json](EXAMPLE_project.trug.json) — a starter tracker with epics, tasks, and BLOCKS dependency edges. Copy it, replace the placeholder content, and your LLM has a project map.

--- a/installers/pip/src/trugs_agent/templates/FOLDER/AGENT.md
+++ b/installers/pip/src/trugs_agent/templates/FOLDER/AGENT.md
@@ -1,0 +1,311 @@
+# FOLDER — Agent Instructions
+
+<trl>
+DEFINE "folder.trug.json" AS DATA graph 'for MODULE folder.
+EACH MODULE folder SHALL CONTAIN EXACTLY A FILE folder.trug.json.
+FILE folder.trug.json SHALL 'be RECORD ground_truth 'for MODULE folder.
+AGENT SHALL READ FILE folder.trug.json 'at ENTRY MODULE folder.
+AGENT SHALL UPDATE FILE folder.trug.json WHEN AGENT MODIFY MODULE folder.
+</trl>
+
+A `folder.trug.json` is a TRUG graph that indexes a directory. Every file is a node. Every relationship is an edge. You read it to know what exists, what each file does, and how things connect — without opening every file.
+
+---
+
+## The Four-File Pattern
+
+<trl>
+EACH MODULE folder MAY CONTAIN FILE folder.trug.json AND FILE README.md AND FILE ARCHITECTURE.md AND FILE AAA.md.
+FILE folder.trug.json SHALL 'be RECORD ground_truth.
+FILE README.md SHALL 'be RECORD narrative 'for PARTY human.
+FILE ARCHITECTURE.md SHALL 'be RECORD auto_generated FROM FILE folder.trug.json.
+FILE AAA.md SHALL 'be RECORD auto_generated FROM ENDPOINT github_issue.
+NO AGENT SHALL MODIFY FILE ARCHITECTURE.md.
+NO AGENT SHALL MODIFY FILE AAA.md.
+</trl>
+
+| File | Owner | Agent Action |
+|------|-------|-------------|
+| **folder.trug.json** | Human-maintained | Read first. Update when files change. |
+| **README.md** | Human-written | Read for motivation if needed. |
+| **ARCHITECTURE.md** | Auto-generated nightly | Never edit. Read for rendered reference. |
+| **AAA.md** | Auto-generated from GitHub Issues | Never edit. Read for active work spec. |
+
+### How to Enter a Folder
+
+<trl>
+AGENT SHALL READ FILE folder.trug.json THEN READ FILE AAA.md IF EXISTS THEN READ FILE README.md IF REQUIRED.
+AGENT SHALL SKIP FILE ARCHITECTURE.md — DATA 'is 'in FILE folder.trug.json.
+AGENT SHALL SKIP ALL FILE 'with PREFIX "zzz_" — RECORD archived.
+</trl>
+
+1. Read `folder.trug.json` — know every file, component, and relationship
+2. Read `AAA.md` (if present) — know the current task and phase
+3. Read `README.md` only if you need motivation or context
+4. Skip `ARCHITECTURE.md` — same data as the TRUG, just rendered
+5. Skip `zzz_*` files — archived, irrelevant
+
+---
+
+## Node Types
+
+<trl>
+DEFINE "FOLDER" AS DATA node 'at KILO METRIC_LEVEL — THE FOLDER ITSELF.
+DEFINE "DOCUMENT" AS DATA node 'at BASE METRIC_LEVEL — MARKDOWN FILE.
+DEFINE "SPECIFICATION" AS DATA node 'at BASE METRIC_LEVEL — SPEC OR PROTOCOL FILE.
+DEFINE "COMPONENT" AS DATA node 'at DEKA METRIC_LEVEL — MAJOR CODE SUBSYSTEM.
+DEFINE "TEST_SUITE" AS DATA node 'at BASE METRIC_LEVEL — TEST DIRECTORY OR COLLECTION.
+DEFINE "EXAMPLE_SET" AS DATA node 'at BASE METRIC_LEVEL — EXAMPLES DIRECTORY.
+DEFINE "SCHEMA" AS DATA node 'at BASE METRIC_LEVEL — JSON SCHEMA FILE.
+DEFINE "TEMPLATE" AS DATA node 'at BASE METRIC_LEVEL — GENERATOR TEMPLATE.
+EACH DATA node SHALL CONTAIN RECORD id AND RECORD type AND RECORD properties AND RECORD parent_id AND RECORD contains AND RECORD metric_level AND RECORD dimension.
+</trl>
+
+| Type | What It Represents | metric_level |
+|------|-------------------|-------------|
+| `FOLDER` | The folder itself — exactly one, root node | `KILO_FOLDER` |
+| `DOCUMENT` | Markdown docs (README, guides, references) | `BASE_DOCUMENT` |
+| `SPECIFICATION` | Spec and protocol files — define behavior | `BASE_SPECIFICATION` |
+| `COMPONENT` | A major code subsystem (validator, CLI, engine) | `DEKA_COMPONENT` |
+| `TEST_SUITE` | A test directory or collection | `BASE_TEST_SUITE` |
+| `EXAMPLE_SET` | An examples directory or collection | `BASE_EXAMPLE_SET` |
+| `SCHEMA` | A JSON Schema file | `BASE_SCHEMA` |
+| `TEMPLATE` | A generator template | `BASE_TEMPLATE` |
+
+### Node Properties
+
+<trl>
+EACH DATA node SHALL CONTAIN RECORD name 'in RECORD properties.
+EACH DATA node SHALL CONTAIN RECORD purpose 'in RECORD properties — A RECORD sentence DESCRIBING WHAT FILE DOES.
+DATA node MAY CONTAIN RECORD format AND RECORD status AND RECORD stale AND RECORD verified.
+IF RECORD stale EQUALS TRUE THEN FILE 'is MISSING FROM DISK.
+IF RECORD planned EQUALS TRUE THEN FILE 'will 'be CREATED BY FUTURE RECORD issue.
+IF RECORD verified EQUALS TRUE THEN PARTY human 'has CONFIRMED DATA node 'is ACCURATE.
+</trl>
+
+Every node has a `purpose` field — one sentence explaining what the file does. This is what saves tokens: you read the purpose instead of opening the file.
+
+```json
+{
+  "id": "doc_specification",
+  "type": "SPECIFICATION",
+  "properties": {
+    "name": "SPEC_computation.md",
+    "purpose": "Formal specification for TRUGS Computation — 23-operation vocabulary, type system, and 6 validation rules",
+    "format": "markdown"
+  },
+  "parent_id": "computation_folder",
+  "contains": [],
+  "metric_level": "BASE_SPECIFICATION",
+  "dimension": "folder_structure"
+}
+```
+
+---
+
+## Edge Relations
+
+<trl>
+DEFINE "contains" AS DATA edge — FOLDER DIRECTLY CONTAINS THIS NODE.
+DEFINE "uses" AS DATA edge — RUNTIME OR BUILD DEPENDENCY.
+DEFINE "produces" AS DATA edge — THIS COMPONENT GENERATES 'that OUTPUT.
+DEFINE "validates" AS DATA edge — THIS NODE VALIDATES 'that NODE.
+DEFINE "implements" AS DATA edge — CODE 'that REALIZES A SPEC.
+DEFINE "tests" AS DATA edge — TEST SUITE COVERS THIS COMPONENT.
+DEFINE "describes" AS DATA edge — DOCUMENT EXPLAINS THIS NODE.
+DEFINE "governs" AS DATA edge — OWNS POLICY OR COMPLIANCE RULES.
+EACH DATA edge SHALL CONTAIN RECORD from_id AND RECORD to_id AND RECORD relation AND RECORD properties.
+RECORD properties SHALL 'be OBJECT — MUST 'be PRESENT EVEN WHEN EMPTY.
+</trl>
+
+| Relation | From → To | Meaning |
+|----------|-----------|---------|
+| `contains` | FOLDER → any | Folder directly contains this node |
+| `uses` | any → COMPONENT, SPEC, SCHEMA | Runtime or build-time dependency |
+| `produces` | COMPONENT, TEMPLATE → DOCUMENT, EXAMPLE_SET | This component generates that output |
+| `validates` | SCHEMA, COMPONENT → any | This node validates that node |
+| `implements` | COMPONENT → SPECIFICATION | Code that realizes a spec |
+| `tests` | TEST_SUITE → COMPONENT | Test suite covers this component |
+| `describes` | DOCUMENT → any | Document explains this node |
+| `governs` | FOLDER, SPECIFICATION → any | Owns policy or compliance rules |
+
+### Edge Format
+
+```json
+{
+  "from_id": "validator_component",
+  "to_id": "spec_validation",
+  "relation": "implements",
+  "properties": {}
+}
+```
+
+### Cross-Folder Edges
+
+<trl>
+DATA edge MAY REFERENCE DATA node 'in ANOTHER MODULE folder.
+CROSS-FOLDER RECORD to_id SHALL USE RECORD syntax "folder_name:node_id".
+EACH MODULE folder SHALL DECLARE ONLY ITS OWN OUTBOUND DATA edge.
+NO MODULE folder SHALL DECLARE DATA edge 'for ANOTHER MODULE folder.
+</trl>
+
+When a node depends on something in another folder, use qualified IDs:
+
+```json
+{
+  "from_id": "validator_component",
+  "to_id": "trugs_protocol:spec_validation",
+  "relation": "implements",
+  "properties": {}
+}
+```
+
+The prefix before `:` is the folder name. Each folder declares its own outbound edges. No folder speaks for another.
+
+---
+
+## Building a folder.trug.json
+
+<trl>
+AGENT SHALL BUILD FILE folder.trug.json FROM RECORD filesystem — NOT FROM FILE AAA.md OR FILE README.md.
+AGENT SHALL COUNT FILE 'on DISK USING RECORD command ls OR find OR wc.
+AGENT SHALL READ RECORD source — FILE pyproject.toml AND RECORD test_runner AND RECORD directory_listing.
+AGENT SHALL VERIFY EACH RECORD numeric_property AGAINST RECORD filesystem 'before COMMIT.
+NO AGENT SHALL USE RECORD prose_document AS SOURCE 'for RECORD count OR RECORD file_list.
+</trl>
+
+### The Hard Rule
+
+**The filesystem is the source of truth.** Not AAA.md. Not README.md. Not prose documents. Count files on disk. Read actual source. Verify every number.
+
+| Data Needed | Source | NOT This |
+|-------------|--------|----------|
+| File counts | `ls`, `find`, `wc -l` | AAA.md prose |
+| Component list | Directory listing + imports | AAA.md component section |
+| Test count | Test runner output | AAA.md status line |
+| Schema list | `ls schemas/*.json` | AAA.md table |
+| Phase/status | AAA.md (this IS intent data) | — |
+| Edge relationships | Code inspection + human judgment | — |
+
+### Step by Step
+
+<trl>
+AGENT SHALL LIST ALL FILE 'in MODULE folder.
+'for EACH FILE AGENT SHALL CREATE DATA node 'with RECORD type AND RECORD purpose.
+AGENT SHALL CREATE EXACTLY A DATA node 'of TYPE FOLDER AS RECORD root.
+AGENT SHALL SET RECORD parent_id AND RECORD contains 'for HIERARCHY.
+AGENT SHALL CREATE DATA edge 'for EACH RECORD relationship 'between DATA node.
+AGENT SHALL VALIDATE FILE folder.trug.json.
+</trl>
+
+1. **List files on disk** — `ls`, `find`
+2. **Create the FOLDER node** — one root node, `parent_id: null`
+3. **Create a node for each file/component** — type it correctly, write a one-sentence purpose
+4. **Set hierarchy** — `parent_id` points up, `contains` points down, both must agree
+5. **Create edges** — `implements`, `tests`, `uses`, `describes`, etc.
+6. **Validate** — run `trugs-folder-check` or `python tools/validate.py`
+
+---
+
+## Lifecycle Properties
+
+<trl>
+IF FILE 'is MISSING FROM DISK THEN AGENT SHALL SET RECORD stale TO TRUE 'on DATA node.
+IF FILE 'will 'be CREATED BY FUTURE RECORD issue THEN PARTY human SHALL SET RECORD planned TO TRUE.
+IF PARTY human CONFIRMS DATA node 'is ACCURATE THEN PARTY human SHALL SET RECORD verified TO TRUE.
+IF FILE folder.trug.json CHANGES AFTER RECORD verified 'is SET THEN RECORD verified SHALL 'be CLEARED.
+</trl>
+
+| Property | Set By | Meaning |
+|----------|--------|---------|
+| `stale: true` | Automation | File was here, now gone from disk |
+| `stale_reason` | Automation | Why the node is stale |
+| `planned: true` | Human | File will be created by a future issue |
+| `planned_issue` | Human | GitHub issue that will create the file |
+| `verified: true` | Human | Human confirmed this node is accurate |
+| `verified_by` | Human | Who verified it |
+| `verified_date` | Human | When it was verified |
+
+### Trust Signal
+
+| verified | stale | Interpretation |
+|----------|-------|---------------|
+| true | false | Fully trusted — human confirmed, unchanged since |
+| false | false | Unreviewed — synced but no human sign-off |
+| false | true | Stale — drift detected, downgrade trust |
+| true | true | Conflict — human verified but drift detected since |
+
+---
+
+## Maintaining folder.trug.json
+
+<trl>
+IF AGENT CREATE FILE 'in MODULE folder THEN AGENT SHALL ADD DATA node TO FILE folder.trug.json.
+IF AGENT DELETE FILE 'in MODULE folder THEN AGENT SHALL SET RECORD stale TO TRUE 'on DATA node.
+IF AGENT CREATE RECORD relationship THEN AGENT SHALL ADD DATA edge.
+AGENT SHALL_NOT REMOVE DATA node — SET RECORD stale INSTEAD.
+AGENT SHALL UPDATE RECORD purpose IF FILE RECORD content CHANGES SIGNIFICANTLY.
+</trl>
+
+- **New file** → add a node with type and purpose
+- **Deleted file** → set `stale: true` on the node (never remove nodes)
+- **New relationship** → add an edge
+- **Changed file** → update the purpose if the file's role changed
+- **Renamed file** → update the `name` property, keep the same `id`
+
+---
+
+## Document Naming Convention
+
+<trl>
+EACH FILE CREATED BY PARTY human SHALL FOLLOW RECORD pattern "TYPE_description.md".
+RECORD TYPE SHALL 'be UPPERCASE — TELLS RECORD type WITHOUT READING FILE.
+RECORD description SHALL 'be LOWERCASE 'with UNDERSCORES.
+</trl>
+
+```
+TYPE_description_in_lowercase.md
+```
+
+Valid types: `VISION`, `SPEC`, `PROPOSAL`, `RESEARCH`, `GUIDE`, `PLAN`, `REPORT`, `ANALYSIS`, `REFERENCE`, `PITCH`, `PROMPT`, `AUDIT`, `STANDARD`, `MIGRATION`, `ROADMAP`, `TODO`
+
+An agent seeing `SPEC_computation.md` knows it's a specification about computation — without opening the file. Compare with `notes.md` or `design.md` where you'd have to read it to find out.
+
+---
+
+## The zzz_ Archive Convention
+
+<trl>
+NO AGENT SHALL READ FILE 'with PREFIX "zzz_".
+NO AGENT SHALL REFERENCE FILE 'with PREFIX "zzz_" 'in DATA graph.
+NO AGENT SHALL CREATE DATA node 'for FILE 'with PREFIX "zzz_".
+FILE 'with PREFIX "zzz_" 'is RECORD archived — INVISIBLE TO AGENT.
+</trl>
+
+Files prefixed with `zzz_` are archived — pending human review before deletion. They sort to the bottom of directory listings. They are invisible to agents and to the graph. Never read, reference, or index them.
+
+---
+
+## CLI Tools
+
+<trl>
+AGENT MAY USE RECORD command "trugs-folder-init" TO CREATE FILE folder.trug.json FROM RECORD filesystem.
+AGENT MAY USE RECORD command "trugs-folder-sync" TO UPDATE FILE folder.trug.json FROM RECORD filesystem.
+AGENT SHALL USE RECORD command "trugs-folder-check" TO VALIDATE FILE folder.trug.json.
+AGENT MAY USE RECORD command "trugs-folder-render" TO GENERATE FILE ARCHITECTURE.md FROM FILE folder.trug.json.
+</trl>
+
+```bash
+trugs-folder-init [PATH]              # Generate starter folder.trug.json from directory scan
+trugs-folder-sync [PATH] [--all]      # Add nodes for new files, mark missing files stale
+trugs-folder-check [PATH] [--all]     # Validate folder.trug.json — exit 0 = pass, exit 1 = errors
+trugs-folder-render [PATH] [--all]    # Regenerate ARCHITECTURE.md from folder.trug.json
+```
+
+`trugs-folder-sync` rules:
+- Adds nodes for new files found on disk
+- Sets `stale: true` on nodes whose files are missing
+- Never removes nodes
+- Never modifies human-curated edges
+
+See [EXAMPLE_folder.trug.json](EXAMPLE_folder.trug.json) for a complete example.

--- a/installers/pip/src/trugs_agent/templates/FOLDER/EXAMPLE_folder.trug.json
+++ b/installers/pip/src/trugs_agent/templates/FOLDER/EXAMPLE_folder.trug.json
@@ -1,0 +1,167 @@
+{
+  "name": "Auth Module",
+  "version": "1.0.0",
+  "type": "MODULE",
+  "description": "Authentication and authorization — JWT validation, session management, role-based access control",
+  "dimensions": {
+    "folder_structure": {
+      "description": "Auth module file and component structure",
+      "base_level": "BASE"
+    }
+  },
+  "capabilities": {
+    "extensions": [],
+    "vocabularies": ["project_v1"],
+    "profiles": []
+  },
+  "nodes": [
+    {
+      "id": "auth_folder",
+      "type": "FOLDER",
+      "properties": {
+        "name": "auth",
+        "purpose": "Authentication and authorization module — JWT tokens, sessions, RBAC",
+        "verified": false,
+        "stale": false
+      },
+      "parent_id": null,
+      "contains": ["spec_auth", "component_jwt", "component_sessions", "component_rbac", "doc_readme", "test_suite"],
+      "metric_level": "KILO_FOLDER",
+      "dimension": "folder_structure"
+    },
+    {
+      "id": "spec_auth",
+      "type": "SPECIFICATION",
+      "properties": {
+        "name": "SPEC_auth.md",
+        "purpose": "Formal auth specification — token format, expiration rules, role hierarchy, rate limits",
+        "format": "markdown"
+      },
+      "parent_id": "auth_folder",
+      "contains": [],
+      "metric_level": "BASE_SPECIFICATION",
+      "dimension": "folder_structure"
+    },
+    {
+      "id": "component_jwt",
+      "type": "COMPONENT",
+      "properties": {
+        "name": "jwt_handler.py",
+        "purpose": "JWT token creation, validation, and refresh — HS256, 15min access / 7d refresh",
+        "language": "python"
+      },
+      "parent_id": "auth_folder",
+      "contains": [],
+      "metric_level": "DEKA_COMPONENT",
+      "dimension": "folder_structure"
+    },
+    {
+      "id": "component_sessions",
+      "type": "COMPONENT",
+      "properties": {
+        "name": "sessions.py",
+        "purpose": "Server-side session store — Redis-backed, 24h TTL, sliding expiration",
+        "language": "python"
+      },
+      "parent_id": "auth_folder",
+      "contains": [],
+      "metric_level": "DEKA_COMPONENT",
+      "dimension": "folder_structure"
+    },
+    {
+      "id": "component_rbac",
+      "type": "COMPONENT",
+      "properties": {
+        "name": "rbac.py",
+        "purpose": "Role-based access control — admin/editor/viewer hierarchy, permission checks",
+        "language": "python"
+      },
+      "parent_id": "auth_folder",
+      "contains": [],
+      "metric_level": "DEKA_COMPONENT",
+      "dimension": "folder_structure"
+    },
+    {
+      "id": "doc_readme",
+      "type": "DOCUMENT",
+      "properties": {
+        "name": "README.md",
+        "purpose": "Auth module quickstart — setup, configuration, usage examples",
+        "format": "markdown"
+      },
+      "parent_id": "auth_folder",
+      "contains": [],
+      "metric_level": "BASE_DOCUMENT",
+      "dimension": "folder_structure"
+    },
+    {
+      "id": "test_suite",
+      "type": "TEST_SUITE",
+      "properties": {
+        "name": "tests/",
+        "purpose": "Auth test suite — 43 tests covering JWT, sessions, RBAC, and integration",
+        "test_count": 43
+      },
+      "parent_id": "auth_folder",
+      "contains": [],
+      "metric_level": "BASE_TEST_SUITE",
+      "dimension": "folder_structure"
+    }
+  ],
+  "edges": [
+    {
+      "from_id": "component_jwt",
+      "to_id": "spec_auth",
+      "relation": "implements",
+      "properties": {"scope": "JWT token format and expiration rules"}
+    },
+    {
+      "from_id": "component_sessions",
+      "to_id": "spec_auth",
+      "relation": "implements",
+      "properties": {"scope": "Session TTL and sliding expiration"}
+    },
+    {
+      "from_id": "component_rbac",
+      "to_id": "spec_auth",
+      "relation": "implements",
+      "properties": {"scope": "Role hierarchy and permission model"}
+    },
+    {
+      "from_id": "component_rbac",
+      "to_id": "component_jwt",
+      "relation": "uses",
+      "properties": {"reason": "RBAC reads role claims from JWT payload"}
+    },
+    {
+      "from_id": "test_suite",
+      "to_id": "component_jwt",
+      "relation": "tests",
+      "properties": {}
+    },
+    {
+      "from_id": "test_suite",
+      "to_id": "component_sessions",
+      "relation": "tests",
+      "properties": {}
+    },
+    {
+      "from_id": "test_suite",
+      "to_id": "component_rbac",
+      "relation": "tests",
+      "properties": {}
+    },
+    {
+      "from_id": "doc_readme",
+      "to_id": "auth_folder",
+      "relation": "describes",
+      "properties": {}
+    },
+    {
+      "from_id": "component_sessions",
+      "to_id": "infrastructure:redis",
+      "relation": "uses",
+      "properties": {"reason": "Redis for session storage"}
+    }
+  ]
+}

--- a/installers/pip/src/trugs_agent/templates/FOLDER/README.md
+++ b/installers/pip/src/trugs_agent/templates/FOLDER/README.md
@@ -1,0 +1,74 @@
+# FOLDER — Machine-Readable Filesystem Index
+
+A `folder.trug.json` is a TRUG graph that indexes the contents of a directory — every file, every component, every relationship — so your LLM can navigate a codebase without reading everything in it.
+
+## When to Use
+
+Any project folder that an LLM will work in repeatedly. The cost is one JSON file per folder. The payoff is that your LLM stops wasting tokens reading files just to figure out what they are.
+
+## The Problem It Solves
+
+LLMs read everything in their context window. Every file costs tokens. Every irrelevant file wastes capacity. Every ambiguously named file forces the agent to open it just to decide if it matters.
+
+The solution is not fewer files — it's a machine-readable index. One JSON file tells the agent what exists, what each file does, and how things relate. The agent reads the index, picks what it needs, and skips everything else.
+
+## The Four-File Pattern
+
+Every folder that matters has up to four standard files:
+
+| File | Who Writes It | What It Does |
+|------|--------------|--------------|
+| **folder.trug.json** | Human (maintained) | Machine-readable graph — ground truth of contents and relationships |
+| **README.md** | Human | Prose quickstart — motivation, purpose, getting started |
+| **ARCHITECTURE.md** | Auto-generated | Dense technical reference rendered from folder.trug.json |
+| **AAA.md** | Auto-generated | Active work spec rendered from GitHub Issues |
+
+An agent entering any folder reads `folder.trug.json` first. Two to three files and it has full context.
+
+## How It Works
+
+A `folder.trug.json` is a TRUG graph where:
+- **Nodes** are files, components, specs, test suites, schemas — anything in the folder
+- **Edges** are relationships: `implements`, `tests`, `uses`, `describes`, `governs`
+- **Hierarchy** shows what belongs to what via `parent_id` and `contains`
+
+Each node has a `purpose` field — one sentence explaining what the file does. An agent reads this instead of opening the file.
+
+## Node Types
+
+| Type | Represents |
+|------|-----------|
+| `FOLDER` | The folder itself (exactly one, root node) |
+| `DOCUMENT` | Markdown docs (README, guides, references) |
+| `SPECIFICATION` | Spec and protocol files |
+| `COMPONENT` | A major code subsystem |
+| `TEST_SUITE` | A test directory or collection |
+| `EXAMPLE_SET` | An examples directory or collection |
+| `SCHEMA` | A JSON Schema file |
+| `TEMPLATE` | A generator template |
+
+## Edge Relations
+
+| Relation | Meaning |
+|----------|---------|
+| `contains` | Folder directly contains this node |
+| `uses` | Runtime or build-time dependency |
+| `produces` | This component generates that output |
+| `validates` | This node validates that node |
+| `implements` | Code that realizes a spec |
+| `tests` | Test suite covers this component |
+| `describes` | Document explains this node |
+| `governs` | Owns policy or compliance rules |
+
+## CLI Tools
+
+```bash
+trugs-folder-init [PATH]    # Generate starter folder.trug.json from directory scan
+trugs-folder-sync [PATH]    # Update nodes for new/missing files
+trugs-folder-check [PATH]   # Validate folder.trug.json — exit 0 = pass
+trugs-folder-render [PATH]  # Regenerate ARCHITECTURE.md from folder.trug.json
+```
+
+## Example
+
+See [EXAMPLE_folder.trug.json](EXAMPLE_folder.trug.json) for a real folder.trug.json from a Python module with specs, components, tests, and cross-folder edges.

--- a/installers/pip/src/trugs_agent/templates/MEMORY/AGENT.md
+++ b/installers/pip/src/trugs_agent/templates/MEMORY/AGENT.md
@@ -1,0 +1,179 @@
+# Memory — Agent Instructions
+
+<trl>
+DEFINE "Memory" AS MODULE CONTAINS RECORD user AND RECORD feedback AND RECORD project AND RECORD reference.
+AGENT SHALL READ FILE MEMORY.md 'at ENTRY RECORD session.
+AGENT SHALL WRITE RECORD decision TO MODULE Memory DURING RECORD session.
+AGENT SHALL WRITE RECORD summary TO MODULE Memory 'at EXIT RECORD session.
+</trl>
+
+Memory is how you persist context across sessions. Decisions, preferences, project state, and pointers to external systems — stored as markdown files, indexed by MEMORY.md.
+
+---
+
+## Memory Types
+
+<trl>
+DEFINE "user" AS RECORD 'for PARTY human CONTAINS RECORD role AND RECORD preference AND RECORD expertise.
+DEFINE "feedback" AS RECORD 'for RECORD correction OR RECORD confirmation.
+DEFINE "project" AS RECORD 'for RECORD decision OR RECORD status OR RECORD deadline.
+DEFINE "reference" AS RECORD 'for ENDPOINT external_system.
+</trl>
+
+| Type | Save When | Example |
+|------|-----------|---------|
+| **user** | You learn about their role or preferences | "User is a data scientist focused on observability" |
+| **feedback** | They correct you OR confirm a non-obvious approach | "Don't mock the database — use real DB in tests" |
+| **project** | You learn who does what, why, or by when | "Merge freeze 2026-03-05 for mobile release" |
+| **reference** | You learn about external resources | "Pipeline bugs tracked in Linear project INGEST" |
+
+### User Memories
+
+<trl>
+AGENT SHALL WRITE RECORD user WHEN AGENT LEARN RECORD role OR RECORD preference OR RECORD expertise 'of PARTY human.
+RECORD user SHALL HELP AGENT TAILOR RECORD response TO PARTY human.
+</trl>
+
+Who the human is. Their role, expertise, how they like to work. A senior engineer gets different explanations than a student. A backend developer gets frontend concepts explained through backend analogies.
+
+### Feedback Memories
+
+<trl>
+AGENT SHALL WRITE RECORD feedback WHEN PARTY human CORRECT RECORD approach.
+AGENT SHALL WRITE RECORD feedback WHEN PARTY human CONFIRM RECORD non_obvious_approach.
+EACH RECORD feedback SHALL CONTAIN RECORD rule AND RECORD why AND RECORD how_to_apply.
+</trl>
+
+What the human has corrected or confirmed. Both matter — corrections prevent repeating mistakes, confirmations prevent abandoning validated approaches. Always record the **why** so you can judge edge cases.
+
+### Project Memories
+
+<trl>
+AGENT SHALL WRITE RECORD project WHEN AGENT LEARN RECORD decision OR RECORD deadline OR RECORD status.
+AGENT SHALL CONVERT ALL RECORD relative_date TO RECORD absolute_date 'before WRITE.
+EACH RECORD project SHALL CONTAIN RECORD fact AND RECORD why AND RECORD how_to_apply.
+</trl>
+
+What's happening in the project. Decisions, deadlines, who's doing what. Always convert relative dates ("Thursday") to absolute dates ("2026-03-05") so the memory stays useful.
+
+### Reference Memories
+
+<trl>
+AGENT SHALL WRITE RECORD reference WHEN AGENT LEARN RECORD location 'of RECORD external_resource.
+RECORD reference SHALL CONTAIN RECORD system AND RECORD purpose AND RECORD url_or_path.
+</trl>
+
+Where to find things outside the codebase. Bug trackers, dashboards, documentation, Slack channels.
+
+---
+
+## What NOT to Save
+
+<trl>
+NO AGENT SHALL WRITE RECORD memory 'for DATA code_pattern.
+NO AGENT SHALL WRITE RECORD memory 'for DATA git_history.
+NO AGENT SHALL WRITE RECORD memory 'for DATA 'that EXISTS 'in FILE CLAUDE.md.
+NO AGENT SHALL WRITE RECORD memory 'for RECORD ephemeral_task.
+NO AGENT SHALL WRITE RECORD memory 'for DATA file_path OR DATA architecture.
+</trl>
+
+Don't save what you can derive:
+- **Code patterns** — read the code
+- **Git history** — run git log
+- **File paths** — use glob/grep
+- **Architecture** — read the TRUGs
+- **Ephemeral state** — current task context dies with the session
+- **Anything in CLAUDE.md** — it's already loaded every session
+
+---
+
+## Memory File Format
+
+<trl>
+EACH RECORD memory SHALL PERSIST AS FILE 'with RECORD frontmatter AND RECORD content.
+RECORD frontmatter SHALL CONTAIN RECORD name AND RECORD description AND RECORD type.
+RECORD description SHALL 'be SPECIFIC — USED TO DECIDE RECORD relevance 'in FUTURE SESSION.
+</trl>
+
+```markdown
+---
+name: short title
+description: one-line description — be specific, this decides relevance
+type: user|feedback|project|reference
+---
+
+Content here.
+
+**Why:** reason for the decision
+**How to apply:** when this should influence future work
+```
+
+---
+
+## MEMORY.md Index
+
+<trl>
+FILE MEMORY.md SHALL CONTAIN A RECORD pointer 'for EACH RECORD memory.
+EACH RECORD pointer SHALL 'be LESS_THAN 150 STRING characters.
+FILE MEMORY.md SHALL 'be ORGANIZED BY RECORD type.
+AGENT SHALL UPDATE FILE MEMORY.md WHEN AGENT CREATE OR DELETE RECORD memory.
+</trl>
+
+MEMORY.md is an index, not a memory. One line per entry, under 150 characters. Organized by type.
+
+```markdown
+# Memory Index
+
+## User
+- [user_role.md](user_role.md) — Senior backend engineer, new to React
+
+## Feedback
+- [feedback_no_mocks.md](feedback_no_mocks.md) — Integration tests hit real DB, not mocks
+
+## Project
+- [project_freeze.md](project_freeze.md) — Merge freeze 2026-03-05 for mobile release
+
+## Reference
+- [reference_linear.md](reference_linear.md) — Pipeline bugs in Linear project "INGEST"
+```
+
+---
+
+## Session Lifecycle
+
+<trl>
+AGENT SHALL READ FILE MEMORY.md 'at ENTRY RECORD session.
+AGENT SHALL WRITE RECORD decision TO MODULE Memory WHEN RECORD decision EXISTS.
+AGENT SHALL WRITE RECORD session_summary 'at EXIT RECORD session.
+AGENT SHALL WRITE RECORD pointer TO FILE MEMORY.md 'for EACH NEW RECORD memory.
+</trl>
+
+### Session Start
+
+Read MEMORY.md. Load relevant memories based on the task at hand. Don't load everything — load what's relevant.
+
+### During Session
+
+Save memories as they happen. When the human makes a decision, save it. When they correct you, save the feedback. Don't batch — save immediately.
+
+### Session End
+
+Write a session summary: what was accomplished, what decisions were made, what's left to do. Update MEMORY.md with any new entries.
+
+---
+
+## Memory Hygiene
+
+<trl>
+AGENT SHALL_NOT WRITE RECORD memory 'that DUPLICATES EXISTING RECORD memory.
+AGENT SHALL UPDATE RECORD memory WHEN RECORD fact CHANGES.
+AGENT SHALL DELETE RECORD memory WHEN RECORD fact 'is NO_LONGER VALID.
+AGENT SHALL VERIFY RECORD memory 'before RECOMMEND RECORD action BASED_ON RECORD memory.
+</trl>
+
+- **No duplicates** — check before writing. Update existing memories instead.
+- **Update stale memories** — facts change. When they do, update the memory.
+- **Delete obsolete memories** — if a decision was reversed or a deadline passed, remove it.
+- **Verify before acting** — a memory that names a file or function is a claim about the past. Check that it still exists before recommending it.
+
+See [EXAMPLE_MEMORY.md](EXAMPLE_MEMORY.md) for a starter index.

--- a/installers/pip/src/trugs_agent/templates/MEMORY/EXAMPLE_MEMORY.md
+++ b/installers/pip/src/trugs_agent/templates/MEMORY/EXAMPLE_MEMORY.md
@@ -1,0 +1,14 @@
+# Memory Index
+
+## User
+- [user_role.md](user_role.md) — Senior backend engineer, new to React frontend
+
+## Feedback
+- [feedback_no_mocks.md](feedback_no_mocks.md) — Integration tests must hit real DB, not mocks
+- [feedback_single_pr.md](feedback_single_pr.md) — Prefer bundled PRs over many small ones for refactors
+
+## Project
+- [project_release_freeze.md](project_release_freeze.md) — Merge freeze 2026-03-05 for mobile release cut
+
+## Reference
+- [reference_linear_bugs.md](reference_linear_bugs.md) — Pipeline bugs tracked in Linear project "INGEST"

--- a/installers/pip/src/trugs_agent/templates/MEMORY/README.md
+++ b/installers/pip/src/trugs_agent/templates/MEMORY/README.md
@@ -1,0 +1,39 @@
+# Memory — Persistent Context Across Sessions
+
+Memory lets your LLM remember decisions, preferences, and project state between conversations. No more repeating yourself.
+
+## When to Use
+
+Every project benefits from memory. It's lightweight — a few markdown files that accumulate over time.
+
+## How It Works
+
+Memory is a folder of markdown files indexed by `MEMORY.md`:
+
+```
+MEMORY/
+  MEMORY.md              ← Index (one-line pointers)
+  user_role.md           ← Who you are
+  feedback_no_mocks.md   ← What you've corrected
+  project_freeze.md      ← What's happening
+  reference_linear.md    ← Where to find things
+```
+
+Four memory types:
+
+| Type | Save When | Example |
+|------|-----------|---------|
+| **user** | You learn about their role or preferences | "Senior backend engineer, new to React" |
+| **feedback** | They correct or confirm an approach | "Don't mock the database in tests" |
+| **project** | You learn who/what/why/when | "Merge freeze starts March 5" |
+| **reference** | You learn about external resources | "Bugs tracked in Linear project INGEST" |
+
+Your LLM reads `MEMORY.md` at session start. Saves new memories when decisions are made. Updates stale memories when things change.
+
+## Key Rule
+
+Memory stores what can't be derived from code or git history. Don't save file paths, architecture, or code patterns — those belong in the code. Save the *why* behind decisions, user preferences, and pointers to external systems.
+
+## Example
+
+See [EXAMPLE_MEMORY.md](EXAMPLE_MEMORY.md) for a starter index and the format for individual memory files.

--- a/installers/pip/src/trugs_agent/templates/SKILLS/AGENT.md
+++ b/installers/pip/src/trugs_agent/templates/SKILLS/AGENT.md
@@ -1,0 +1,367 @@
+# Skills — Agent Instructions
+
+<trl>
+DEFINE "Skill" AS FUNCTION.
+EACH FUNCTION Skill CONTAINS RECORD name AND RECORD description AND RECORD input AND RECORD output.
+AGENT SHALL EXECUTE FUNCTION Skill WHEN PARTY human REQUESTS RECORD name.
+EACH FUNCTION Skill SHALL EXECUTE STRICTLY A RECORD specification.
+EACH FUNCTION Skill SHALL PRODUCE RECORD output THEN RESPOND TO PARTY human.
+</trl>
+
+Skills are named actions an agent can execute on command. Each skill has one job, one input, one output. Primitives do one thing. Compounds sequence primitives with HITM gates between stages.
+
+---
+
+## Primitive vs Compound
+
+<trl>
+DEFINE "primitive" AS FUNCTION 'that CONTAINS EXACTLY A RECORD action.
+DEFINE "compound" AS FUNCTION 'that CONTAINS MULTIPLE FUNCTION primitive SEQUENTIAL.
+EACH FUNCTION primitive SHALL PRODUCE RECORD output THEN RESPOND TO PARTY human.
+EACH FUNCTION compound SHALL EXECUTE EACH FUNCTION primitive SEQUENTIAL.
+FUNCTION compound MAY REQUIRE PARTY human APPROVE RESULT 'at RECORD hitm_gate 'between FUNCTION primitive.
+</trl>
+
+A **primitive** does one atomic thing — read a file, run a command, write a node, send an email. It cannot be decomposed further.
+
+A **compound** sequences primitives. Between stages, it may pause for human approval (HITM gate). Compounds are how agents perform multi-step workflows autonomously.
+
+The rule: if a skill contains `THEN`, it is compound. If it does not, it is primitive.
+
+---
+
+## Primitive Skills
+
+### Git Primitives
+
+<trl>
+DEFINE "git-status" AS FUNCTION.
+FUNCTION git-status SHALL READ DATA working_tree THEN RESPOND 'with RECORD uncommitted AND RECORD unpushed.
+</trl>
+
+Reports uncommitted changes and unpushed commits. No side effects.
+
+<trl>
+DEFINE "git-commit" AS FUNCTION.
+FUNCTION git-commit SHALL REQUIRE RECORD message FROM PARTY human.
+FUNCTION git-commit SHALL WRITE ALL RECORD staged_change TO DATA repository 'with RECORD message.
+FUNCTION git-commit SHALL_NOT WRITE TO ENDPOINT main.
+FUNCTION git-commit SHALL_NOT WRITE TO ENDPOINT master.
+</trl>
+
+Stage, commit, and push changes on the current branch. Never commits to main.
+
+<trl>
+DEFINE "git-pr" AS FUNCTION.
+FUNCTION git-pr SHALL CREATE RESOURCE pull_request FROM RECORD branch TO ENDPOINT main.
+FUNCTION git-pr SHALL SEND RESOURCE pull_request TO PARTY human THEN EXIT.
+PARTY human SHALL APPROVE RESOURCE pull_request THEN MERGE RESULT TO ENDPOINT main.
+AGENT SHALL_NOT MERGE RESOURCE pull_request.
+</trl>
+
+Create a pull request and return the URL. The agent stops — only the human merges.
+
+<trl>
+DEFINE "git-branch" AS FUNCTION.
+FUNCTION git-branch SHALL CREATE RESOURCE branch FROM ENDPOINT main.
+FUNCTION git-branch SHALL REQUIRE RECORD name 'that CONTAINS RECORD issue_number OR RECORD description.
+</trl>
+
+Create a feature branch from main. Branch name includes the issue number when one exists.
+
+---
+
+### GitHub Primitives
+
+<trl>
+DEFINE "gh-issues" AS FUNCTION.
+FUNCTION gh-issues SHALL READ ALL RECORD issue FROM ENDPOINT github 'with RECORD state AND RECORD count.
+FUNCTION gh-issues MAY READ A RECORD issue BY RECORD number THEN RESPOND 'with RECORD title AND RECORD state AND RECORD labels.
+</trl>
+
+List open issues with count, or view a single issue by number.
+
+<trl>
+DEFINE "gh-prs" AS FUNCTION.
+FUNCTION gh-prs SHALL READ ALL RESOURCE pull_request FROM ENDPOINT github 'with RECORD state.
+FUNCTION gh-prs MAY READ RECORD diff FROM A RESOURCE pull_request BY RECORD number.
+</trl>
+
+List pull requests (open or merged), or get the file diff from a specific PR.
+
+---
+
+### TRUG Graph Primitives
+
+<trl>
+DEFINE "trug-sync" AS FUNCTION.
+FUNCTION trug-sync SHALL READ DATA filesystem THEN WRITE RECORD node 'for EACH NEW FILE TO FILE folder.trug.json.
+FUNCTION trug-sync SHALL VALIDATE EACH RECORD node SUBJECT_TO DATA filesystem.
+FUNCTION trug-sync SHALL MARK RECORD node AS PENDING IF FILE 'is 'not FOUND.
+FUNCTION trug-sync SHALL_NOT REPLACE ANY RECORD node.
+</trl>
+
+Run `trugs-folder-sync` on a folder. Adds nodes for new files, marks missing files stale. Never removes nodes.
+
+<trl>
+DEFINE "trug-check" AS FUNCTION.
+FUNCTION trug-check SHALL VALIDATE FILE folder.trug.json SUBJECT_TO RECORD rule.
+FUNCTION trug-check SHALL RESPOND 'with RECORD result AS VALID OR INVALID.
+IF RECORD result 'is INVALID THEN FUNCTION trug-check SHALL RESPOND 'with EACH RECORD error.
+</trl>
+
+Run `trugs-folder-check` to validate a folder.trug.json against structural rules. Returns pass/fail with error details.
+
+<trl>
+DEFINE "trug-clean" AS FUNCTION.
+FUNCTION trug-clean SHALL READ FILE folder.trug.json THEN FILTER ALL RECORD edge 'where RECORD from_id OR RECORD to_id 'is INVALID.
+FUNCTION trug-clean SHALL FILTER ALL RECORD node 'where RECORD stale EQUALS BOOLEAN 'true AND NO RECORD edge REFERENCES RECORD node.
+FUNCTION trug-clean SHALL VALIDATE EACH RECORD path SUBJECT_TO DATA filesystem.
+FUNCTION trug-clean SHALL MARK RECORD node AS PENDING IF RECORD path 'is INVALID.
+PARTY human SHALL APPROVE RESULT 'before FUNCTION trug-clean SHALL WRITE TO FILE folder.trug.json.
+</trl>
+
+Remove orphaned edges (dangling references), remove dead stale nodes (no remaining edges), mark nodes with broken paths. Presents findings for HITM approval before saving.
+
+<trl>
+DEFINE "trug-edge" AS FUNCTION.
+FUNCTION trug-edge SHALL REQUIRE RECORD from_file.
+FUNCTION trug-edge MAY REQUIRE RECORD to_file AND RECORD relation.
+IF RECORD to_file 'is 'not PROVIDED THEN FUNCTION trug-edge SHALL READ RECORD from_file THEN RESPOND 'with EACH RECORD proposed_edge.
+PARTY human SHALL APPROVE EACH RECORD proposed_edge 'before WRITE.
+FUNCTION trug-edge SHALL WRITE RECORD edge TO FILE folder.trug.json.
+</trl>
+
+Add or infer edges. Three modes: smart (one file — infer everything), directed (two files — infer relation), explicit (all three specified). Always asks for approval in smart/directed mode.
+
+---
+
+### Memory Primitives
+
+<trl>
+DEFINE "memory-save" AS FUNCTION.
+FUNCTION memory-save SHALL REQUIRE RECORD content AND RECORD type AND RECORD name.
+RECORD type 'is "user" OR "feedback" OR "project" OR "reference".
+FUNCTION memory-save SHALL WRITE FILE memory_record TO NAMESPACE memory.
+FUNCTION memory-save SHALL WRITE RECORD pointer TO FILE MEMORY.md.
+</trl>
+
+Write a memory file with frontmatter (name, description, type) and add a one-line pointer to MEMORY.md. One memory per call.
+
+<trl>
+DEFINE "memory-read" AS FUNCTION.
+FUNCTION memory-read SHALL READ FILE MEMORY.md THEN RESPOND 'with RECORD index.
+FUNCTION memory-read MAY READ FILE memory_record BY RECORD name.
+</trl>
+
+Read the memory index or a specific memory file. Used at session start to load context.
+
+---
+
+### EPIC Primitives
+
+<trl>
+DEFINE "epic-read" AS FUNCTION.
+FUNCTION epic-read SHALL READ FILE project.trug.json THEN RESPOND 'with DATA present_plan AND DATA portfolio_status AND DATA critical_path.
+FUNCTION epic-read MAY READ FILE epic.trug.json 'for RECORD business_context.
+</trl>
+
+Read the EPIC tracker — present plan, critical path, active issues, portfolio status. Optionally reads business epic if accessible.
+
+<trl>
+DEFINE "epic-sync" AS FUNCTION.
+FUNCTION epic-sync SHALL READ EACH RECORD task FROM FILE project.trug.json.
+FUNCTION epic-sync SHALL VALIDATE EACH RECORD task SUBJECT_TO ENDPOINT github 'by RECORD issue_number.
+IF RECORD task RECORD status 'is INVALID THEN FUNCTION epic-sync SHALL WRITE RECORD status TO FILE project.trug.json.
+</trl>
+
+Sync EPIC task node statuses with GitHub issue states. Updates status, pr_number, completed_date for any task that has drifted from reality.
+
+<trl>
+DEFINE "epic-portfolio" AS FUNCTION.
+FUNCTION epic-portfolio SHALL READ DATA filesystem THEN VALIDATE EACH RECORD folder SUBJECT_TO DATA portfolio_status.
+IF RECORD folder 'is NEW THEN FUNCTION epic-portfolio SHALL WRITE RECORD folder TO DATA portfolio_status.
+IF RECORD folder RECORD phase 'is INVALID THEN FUNCTION epic-portfolio SHALL WRITE RECORD phase.
+</trl>
+
+Update the portfolio_status node in the EPIC. Adds new top-level folders, updates phase for modified folders, verifies TRACKED_BY edges.
+
+---
+
+### Decision Primitive
+
+<trl>
+DEFINE "decisions" AS FUNCTION.
+FUNCTION decisions SHALL READ DATA conversation THEN FILTER ALL RECORD decision.
+RECORD decision 'is RECORD architecture_choice OR RECORD rule_change OR RECORD assumption_change OR RECORD surprising_finding OR RECORD priority_change.
+RECORD decision 'is 'not RECORD routine_code_change OR RECORD bug_fix OR RECORD file_rename.
+FUNCTION decisions SHALL RESPOND 'with EACH RECORD decision TO PARTY human.
+PARTY human SHALL APPROVE EACH RECORD decision 'before FUNCTION memory-save SHALL EXECUTE.
+</trl>
+
+Mine the current conversation for key decisions — architecture choices, new rules, changed assumptions, surprising findings, scope changes. Present to the human for approval, then save each approved decision via `/memory-save`.
+
+---
+
+### Worktree Primitives
+
+<trl>
+DEFINE "worktree-create" AS FUNCTION.
+FUNCTION worktree-create SHALL REQUIRE RECORD issue_number.
+FUNCTION worktree-create SHALL CREATE RESOURCE worktree FROM ENDPOINT main 'for RECORD issue_number.
+FUNCTION worktree-create SHALL_NOT REPLACE ANY RESOURCE worktree.
+</trl>
+
+Create a git worktree for an issue. Each worktree gets its own directory and branch — isolated git state for concurrent development.
+
+<trl>
+DEFINE "worktree-list" AS FUNCTION.
+FUNCTION worktree-list SHALL READ ALL RESOURCE worktree THEN RESPOND 'with EACH RECORD path AND RECORD branch AND RECORD status.
+</trl>
+
+List all active worktrees with their branch and dirty/clean status.
+
+<trl>
+DEFINE "worktree-remove" AS FUNCTION.
+FUNCTION worktree-remove SHALL REQUIRE RECORD issue_number.
+IF RESOURCE worktree CONTAINS RECORD uncommitted_change THEN PARTY human SHALL APPROVE 'before FUNCTION worktree-remove SHALL EXECUTE.
+FUNCTION worktree-remove SHALL REMOVE RESOURCE worktree 'for RECORD issue_number.
+</trl>
+
+Remove a worktree. Warns and asks for approval if uncommitted changes exist.
+
+---
+
+## Compound Skills — Composition
+
+<trl>
+DEFINE "compound" AS FUNCTION 'that CONTAINS MULTIPLE FUNCTION primitive SEQUENTIAL.
+EACH FUNCTION compound SHALL DECLARE EACH FUNCTION primitive 'it CONTAINS.
+FUNCTION compound MAY DEFINE RECORD hitm_gate 'between ANY FUNCTION primitive.
+RECORD hitm_gate SHALL REQUIRE PARTY human APPROVE RESULT 'before FUNCTION compound CONTINUES.
+</trl>
+
+A compound skill is a declared sequence of primitives. HITM gates are inserted where the human must approve before the agent continues. The compound skill definition IS the sequence — no hidden logic.
+
+---
+
+### Example: `/session-open`
+
+<trl>
+DEFINE "session-open" AS FUNCTION compound.
+FUNCTION session-open CONTAINS FUNCTION memory-read THEN FUNCTION epic-read THEN FUNCTION gh-issues THEN FUNCTION gh-prs THEN FUNCTION worktree-list.
+FUNCTION memory-read SHALL READ RECORD session_summary FROM NAMESPACE memory.
+FUNCTION epic-read SHALL READ DATA present_plan FROM FILE project.trug.json.
+FUNCTION gh-issues SHALL READ RECORD count FROM ENDPOINT github.
+FUNCTION gh-prs SHALL READ ALL RESOURCE pull_request 'with RECORD state 'is "open".
+FUNCTION worktree-list SHALL READ ALL RESOURCE worktree.
+FUNCTION session-open SHALL RESPOND TO PARTY human 'with RECORD overview AND RECORD suggested_next_steps.
+PARTY human SHALL APPROVE RECORD direction 'before AGENT CONTINUES.
+</trl>
+
+**Sequence:** Load last session from memory. Read EPIC for current plan and priorities. Count open issues. List open PRs. List worktrees. Present overview and suggest next steps. Wait for the human to choose direction.
+
+---
+
+### Example: `/session-update`
+
+<trl>
+DEFINE "session-update" AS FUNCTION compound.
+FUNCTION session-update CONTAINS FUNCTION git-status THEN FUNCTION git-commit THEN FUNCTION decisions THEN FUNCTION memory-save THEN FUNCTION trug-edge THEN FUNCTION epic-sync THEN FUNCTION epic-portfolio THEN FUNCTION trug-sync THEN FUNCTION git-commit THEN FUNCTION git-pr.
+FUNCTION git-status SHALL READ DATA working_tree.
+IF DATA working_tree CONTAINS RECORD uncommitted_change THEN FUNCTION git-commit SHALL EXECUTE.
+FUNCTION decisions SHALL READ DATA conversation THEN RESPOND 'with EACH RECORD decision.
+RECORD hitm_gate SHALL REQUIRE PARTY human APPROVE EACH RECORD decision.
+FUNCTION memory-save SHALL WRITE EACH RECORD decision TO NAMESPACE memory.
+FUNCTION trug-edge SHALL READ EACH RECORD merged_pr THEN WRITE RECORD edge TO FILE folder.trug.json.
+FUNCTION epic-sync SHALL VALIDATE EACH RECORD task SUBJECT_TO ENDPOINT github.
+FUNCTION epic-portfolio SHALL VALIDATE DATA portfolio_status SUBJECT_TO DATA filesystem.
+FUNCTION trug-sync SHALL EXECUTE 'on EACH RECORD modified_folder.
+FUNCTION git-commit SHALL WRITE ALL RECORD change 'with RECORD message "chore(maintenance)".
+FUNCTION git-pr SHALL CREATE RESOURCE pull_request THEN SEND TO PARTY human.
+</trl>
+
+**Sequence:** Check for uncommitted work — commit and push if needed. Mine conversation for decisions — present for HITM approval. Save approved decisions to memory. Create edges from merged PRs to code nodes. Sync EPIC task statuses with GitHub. Update portfolio status. Run folder-sync on modified folders. Commit all maintenance changes. Create PR — human merges.
+
+---
+
+### Example: `/session-close`
+
+<trl>
+DEFINE "session-close" AS FUNCTION compound.
+FUNCTION session-close CONTAINS FUNCTION session-update THEN FUNCTION memory-save THEN FUNCTION trug-clean THEN FUNCTION epic-sync THEN FUNCTION trug-check THEN FUNCTION worktree-remove THEN FUNCTION git-commit THEN FUNCTION git-pr.
+FUNCTION session-update SHALL EXECUTE 'without FUNCTION git-pr.
+FUNCTION memory-save SHALL WRITE RECORD session_summary TO NAMESPACE memory.
+FUNCTION trug-clean SHALL EXECUTE 'on ALL FILE folder.trug.json.
+RECORD hitm_gate SHALL REQUIRE PARTY human APPROVE RESULT 'of FUNCTION trug-clean.
+FUNCTION epic-sync SHALL WRITE RECORD total_open_issues AND RECORD last_updated TO FILE project.trug.json.
+FUNCTION trug-check SHALL VALIDATE ALL FILE folder.trug.json THEN RESPOND 'with RECORD result.
+FUNCTION worktree-remove SHALL REMOVE EACH RESOURCE worktree 'where RECORD branch 'is MERGED.
+FUNCTION git-commit SHALL WRITE ALL RECORD change 'with RECORD message "chore(stop)".
+FUNCTION git-pr SHALL CREATE RESOURCE pull_request THEN SEND TO PARTY human.
+</trl>
+
+**Sequence:** Run full session-update (without its own PR). Write session summary to memory. Clean all TRUG graphs — remove orphaned edges, stale nodes, broken paths (HITM gate). Sync EPIC issue counts. Validate all TRUGs. Remove merged worktrees. Commit everything. Create single PR — human merges.
+
+---
+
+## Building New Compounds
+
+<trl>
+AGENT MAY DEFINE NEW FUNCTION compound BY COMPOSE EXISTING FUNCTION primitive.
+EACH NEW FUNCTION compound SHALL DECLARE EACH FUNCTION primitive 'it CONTAINS.
+EACH NEW FUNCTION compound SHALL DEFINE RECORD hitm_gate 'where PARTY human APPROVAL 'is REQUIRED.
+AGENT SHALL_NOT DEFINE FUNCTION primitive 'that CONTAINS FUNCTION primitive.
+AGENT MAY DEFINE FUNCTION compound 'that CONTAINS FUNCTION compound.
+</trl>
+
+To create a new compound skill:
+
+1. Identify the primitives you need from the catalog above
+2. Declare the sequence with `CONTAINS ... THEN ... THEN ...`
+3. Insert HITM gates where the human must approve before continuing
+4. A primitive never contains another primitive — it is atomic
+5. A compound may contain other compounds (nesting is allowed)
+
+### Example: Building a hypothetical `/deploy-check`
+
+<trl>
+DEFINE "deploy-check" AS FUNCTION compound.
+FUNCTION deploy-check CONTAINS FUNCTION trug-check THEN FUNCTION trug-sync THEN FUNCTION epic-sync THEN FUNCTION git-status.
+FUNCTION trug-check SHALL VALIDATE ALL FILE folder.trug.json.
+IF RECORD result 'is INVALID THEN FUNCTION deploy-check SHALL RESPOND 'with EACH RECORD error THEN EXIT.
+FUNCTION trug-sync SHALL EXECUTE 'on ALL RECORD folder.
+FUNCTION epic-sync SHALL VALIDATE EACH RECORD task SUBJECT_TO ENDPOINT github.
+FUNCTION git-status SHALL VALIDATE NO RECORD uncommitted_change EXISTS.
+FUNCTION deploy-check SHALL RESPOND 'with RECORD ready AS BOOLEAN.
+</trl>
+
+**Sequence:** Validate all TRUGs — stop if any fail. Sync all folders. Sync EPIC with GitHub. Verify no uncommitted changes. Report ready/not-ready.
+
+---
+
+## Skill File Format
+
+<trl>
+EACH FUNCTION Skill SHALL 'be DEFINED 'in FILE SKILL.md 'in NAMESPACE .claude/skills/RECORD name/.
+FILE SKILL.md SHALL CONTAIN RECORD frontmatter 'with RECORD name AND RECORD description.
+FILE SKILL.md SHALL CONTAIN RECORD specification 'that GOVERNS AGENT EXECUTION.
+</trl>
+
+Each skill lives at `.claude/skills/<name>/SKILL.md`. The file contains:
+
+1. **Frontmatter** — name and one-line description
+2. **Specification** — the exact steps the agent executes
+
+```markdown
+---
+name: skill-name
+description: One-line description of what the skill does
+---
+
+# /skill-name — Title
+
+Steps the agent executes...
+```
+
+The human invokes a skill by typing `/<name>` in the conversation. The agent loads the SKILL.md and executes strictly what it specifies.

--- a/installers/pip/src/trugs_agent/templates/SKILLS/README.md
+++ b/installers/pip/src/trugs_agent/templates/SKILLS/README.md
@@ -1,0 +1,42 @@
+# Skills — Composable Agent Actions
+
+Skills are named actions your LLM executes on command. Type `/skill-name` and the agent does exactly what the skill specifies.
+
+## How It Works
+
+Two kinds of skills:
+
+| Kind | Rule | Example |
+|------|------|---------|
+| **Primitive** | One action, one output, no decomposition | `/git-status`, `/trug-check`, `/email-fetch` |
+| **Compound** | Sequence of primitives with HITM gates | `/session-open`, `/session-close`, `/email-triage` |
+
+## The 19 Primitives
+
+| Category | Skills |
+|----------|--------|
+| **Git** | `git-status`, `git-commit`, `git-pr`, `git-branch` |
+| **GitHub** | `gh-issues`, `gh-prs` |
+| **TRUG Graph** | `trug-sync`, `trug-check`, `trug-clean`, `trug-edge` |
+| **Memory** | `memory-save`, `memory-read` |
+| **EPIC** | `epic-read`, `epic-sync`, `epic-portfolio` |
+| **Decisions** | `decisions` |
+| **Worktree** | `worktree-create`, `worktree-list`, `worktree-remove` |
+
+## Compound Examples
+
+```
+/session-open  = memory-read > epic-read > gh-issues > gh-prs > worktree-list
+/session-update = git-status > git-commit > decisions > memory-save > trug-edge > epic-sync > epic-portfolio > trug-sync > git-commit > git-pr
+/session-close = session-update > memory-save > trug-clean > epic-sync > trug-check > worktree-remove > git-commit > git-pr
+```
+
+The `>` means "then." Where a human must approve before continuing, the compound inserts a HITM gate.
+
+## Key Rule
+
+Primitives are atomic — they never contain other primitives. Compounds sequence primitives. You can build new compounds by composing existing primitives. You can nest compounds inside other compounds.
+
+## Full Specification
+
+See [AGENT.md](AGENT.md) for the complete TRL definitions of all 19 primitives and 3 compound examples.

--- a/installers/pip/src/trugs_agent/templates/TRUGGING/AGENT.md
+++ b/installers/pip/src/trugs_agent/templates/TRUGGING/AGENT.md
@@ -1,0 +1,312 @@
+# Trugging — Agent Instructions
+
+<trl>
+DEFINE "Trugging" AS PIPELINE CONTAINS STAGE system AND STAGE component AND STAGE file_header AND STAGE inline.
+STAGE system SHALL PRODUCE DATA graph AS FILE project.trug.json.
+STAGE component SHALL PRODUCE DATA graph AS FILE folder.trug.json.
+STAGE file_header SHALL PRODUCE RECORD trl_block 'at ENTRY FILE.
+STAGE inline SHALL PRODUCE RECORD trl_block 'at ENTRY FUNCTION.
+EACH STAGE SHALL EXECUTE SEQUENTIAL FROM STAGE system TO STAGE inline.
+</trl>
+
+Trugging is how you describe a program using TRUGs and TRL. Four levels, top-down. Graphs for structure, sentences for behavior.
+
+---
+
+## Level 1: System — `project.trug.json`
+
+<trl>
+AGENT SHALL CREATE FILE project.trug.json 'at ENTRY NAMESPACE project.
+EACH SERVICE SHALL 'be A DATA node 'in FILE project.trug.json.
+EACH STREAM SHALL 'be A DATA node 'in FILE project.trug.json.
+EACH MODULE SHALL 'be A DATA node IF MODULE 'is ENTRY OR EXIT.
+EACH DATA node SHALL CONTAIN RECORD name AND RECORD type AND RECORD dimension.
+AGENT SHALL CREATE DATA edge 'for EACH RECORD dependency 'between DATA node.
+AGENT SHALL_NOT CREATE DATA node 'for RECORD implementation_detail.
+</trl>
+
+### What Goes In
+
+Nodes: services, databases, message queues, external APIs, top-level modules. Things that exist independently and have names a human would recognize.
+
+Edges: `DEPENDS_ON`, `READS`, `WRITES`, `FEEDS`, `AUTHENTICATES`, `IMPLEMENTS`. How the big pieces connect.
+
+### What Stays Out
+
+Internal classes, helper functions, utility files. If it doesn't appear in an architecture diagram, it doesn't appear in the system TRUG.
+
+### Example
+
+```json
+{
+  "name": "My App",
+  "version": "1.0.0",
+  "type": "SYSTEM",
+  "dimensions": {
+    "system": {"description": "System architecture", "base_level": "BASE"}
+  },
+  "capabilities": {"extensions": [], "vocabularies": ["core_v1.0.0"], "profiles": []},
+  "nodes": [
+    {"id": "api", "type": "SERVICE", "properties": {"name": "API Server", "language": "python"}, "parent_id": null, "contains": ["auth", "handlers"], "metric_level": "KILO_SERVICE", "dimension": "system"},
+    {"id": "auth", "type": "MODULE", "properties": {"name": "Auth Module"}, "parent_id": "api", "contains": [], "metric_level": "HECTO_MODULE", "dimension": "system"},
+    {"id": "handlers", "type": "MODULE", "properties": {"name": "Request Handlers"}, "parent_id": "api", "contains": [], "metric_level": "HECTO_MODULE", "dimension": "system"},
+    {"id": "db", "type": "STREAM", "properties": {"name": "PostgreSQL", "engine": "postgres"}, "parent_id": null, "contains": [], "metric_level": "KILO_STREAM", "dimension": "system"},
+    {"id": "queue", "type": "STREAM", "properties": {"name": "Task Queue", "engine": "redis"}, "parent_id": null, "contains": [], "metric_level": "KILO_STREAM", "dimension": "system"}
+  ],
+  "edges": [
+    {"from_id": "api", "to_id": "db", "relation": "READS"},
+    {"from_id": "api", "to_id": "db", "relation": "WRITES"},
+    {"from_id": "api", "to_id": "queue", "relation": "WRITES"},
+    {"from_id": "api", "to_id": "auth", "relation": "DEPENDS_ON"},
+    {"from_id": "handlers", "to_id": "auth", "relation": "DEPENDS_ON"}
+  ]
+}
+```
+
+---
+
+## Level 2: Component — `folder.trug.json`
+
+<trl>
+AGENT SHALL CREATE FILE folder.trug.json 'at ENTRY EACH MODULE.
+EACH FILE 'in MODULE SHALL 'be A DATA node.
+EACH SERVICE OR FUNCTION 'that 'is PUBLIC SHALL 'be A DATA node.
+AGENT SHALL CREATE DATA edge 'for EACH RECORD import 'between FILE.
+AGENT SHALL CREATE DATA edge 'for EACH RECORD call 'between SERVICE OR FUNCTION.
+AGENT SHALL_NOT CREATE DATA node 'for PRIVATE FUNCTION UNLESS FUNCTION 'is CRITICAL.
+</trl>
+
+### What Goes In
+
+Nodes: every file in the folder, plus public classes/services/interfaces that other modules depend on.
+
+Edges: `IMPORTS`, `CALLS`, `IMPLEMENTS`, `EXTENDS`, `CONTAINS`. How the files and their exports relate.
+
+### What Stays Out
+
+Private helper functions, internal constants, implementation details that don't cross a file boundary.
+
+### Example
+
+```json
+{
+  "name": "Auth Module",
+  "version": "1.0.0",
+  "type": "MODULE",
+  "dimensions": {
+    "code": {"description": "Code structure", "base_level": "BASE"}
+  },
+  "capabilities": {"extensions": [], "vocabularies": ["core_v1.0.0"], "profiles": []},
+  "nodes": [
+    {"id": "handler", "type": "FILE", "properties": {"path": "handler.py"}, "parent_id": null, "contains": ["UserService"], "metric_level": "DEKA_FILE", "dimension": "code"},
+    {"id": "models", "type": "FILE", "properties": {"path": "models.py"}, "parent_id": null, "contains": ["User", "Token"], "metric_level": "DEKA_FILE", "dimension": "code"},
+    {"id": "middleware", "type": "FILE", "properties": {"path": "middleware.py"}, "parent_id": null, "contains": ["AuthMiddleware"], "metric_level": "DEKA_FILE", "dimension": "code"},
+    {"id": "UserService", "type": "SERVICE", "properties": {"name": "UserService"}, "parent_id": "handler", "contains": [], "metric_level": "BASE_SERVICE", "dimension": "code"},
+    {"id": "User", "type": "RECORD", "properties": {"name": "User"}, "parent_id": "models", "contains": [], "metric_level": "BASE_RECORD", "dimension": "code"},
+    {"id": "Token", "type": "RECORD", "properties": {"name": "Token"}, "parent_id": "models", "contains": [], "metric_level": "BASE_RECORD", "dimension": "code"},
+    {"id": "AuthMiddleware", "type": "FUNCTION", "properties": {"name": "AuthMiddleware"}, "parent_id": "middleware", "contains": [], "metric_level": "BASE_FUNCTION", "dimension": "code"}
+  ],
+  "edges": [
+    {"from_id": "handler", "to_id": "models", "relation": "IMPORTS"},
+    {"from_id": "middleware", "to_id": "models", "relation": "IMPORTS"},
+    {"from_id": "UserService", "to_id": "User", "relation": "READS"},
+    {"from_id": "UserService", "to_id": "Token", "relation": "VALIDATES"},
+    {"from_id": "AuthMiddleware", "to_id": "Token", "relation": "VALIDATES"}
+  ]
+}
+```
+
+---
+
+## Level 3: File Header — `<trl>` block
+
+<trl>
+AGENT SHALL WRITE RECORD trl_block 'at ENTRY EACH FILE 'that CONTAINS PUBLIC FUNCTION OR SERVICE.
+RECORD trl_block SHALL DESCRIBE ALL RECORD obligation 'for MODULE.
+RECORD trl_block SHALL DESCRIBE ALL RECORD prohibition 'for MODULE.
+RECORD trl_block SHALL DESCRIBE ALL RECORD interface 'that MODULE IMPLEMENTS OR DEPENDS_ON.
+AGENT SHALL_NOT DESCRIBE RECORD implementation_detail 'in RECORD trl_block.
+EACH RECORD trl_block SHALL CONTAIN 3 TO 8 RECORD sentence.
+</trl>
+
+### What Goes In
+
+Obligations (SHALL), prohibitions (SHALL_NOT), interfaces, error handling contracts. What the module promises to do and promises not to do.
+
+### What Stays Out
+
+How it works internally. The header describes the *contract*, not the *mechanism*. An agent reads the header to know what the module guarantees — not how it achieves those guarantees.
+
+### How to Write It
+
+<trl>
+AGENT SHALL IDENTIFY ALL PUBLIC FUNCTION 'in FILE.
+AGENT SHALL IDENTIFY ALL RECORD obligation — WHAT MUST FILE DO.
+AGENT SHALL IDENTIFY ALL RECORD prohibition — WHAT MUST FILE NOT DO.
+AGENT SHALL IDENTIFY ALL RECORD interface — WHAT DOES FILE DEPEND 'on OR EXPOSE.
+AGENT SHALL IDENTIFY ALL RECORD exception — WHAT CAN GO WRONG.
+AGENT SHALL WRITE EACH AS RECORD sentence 'in RECORD trl_block.
+</trl>
+
+### Example
+
+```python
+# <trl>
+# MODULE auth SHALL AUTHENTICATE ALL PARTY 'before GRANT ACCESS TO DATA.
+# MODULE auth SHALL READ DATA credential FROM ENDPOINT environment_variable.
+# MODULE auth SHALL_NOT WRITE DATA credential TO FILE OR STREAM log.
+# MODULE auth SHALL VALIDATE DATA token SUBJECT_TO INTERFACE jwt_schema
+#   THEN RETURN PARTY user OR THROW EXCEPTION auth_error.
+# IF DATA token 'is EXPIRED THEN MODULE auth SHALL DENY PARTY
+#   AND SEND ERROR TO PARTY caller.
+# </trl>
+
+import jwt
+from config import SECRET_KEY
+...
+```
+
+---
+
+## Level 4: Inline — `<trl>` in code comments
+
+<trl>
+AGENT SHALL WRITE RECORD trl_block 'before EACH FUNCTION 'that 'is PUBLIC OR CRITICAL.
+AGENT MAY WRITE RECORD trl_block 'before RECORD code_block 'that 'is COMPLEX.
+EACH INLINE RECORD trl_block SHALL CONTAIN 1 TO 3 RECORD sentence.
+RECORD trl_block SHALL DESCRIBE RECORD contract — INPUT AND OUTPUT AND EXCEPTION.
+AGENT SHALL_NOT WRITE RECORD trl_block 'for TRIVIAL FUNCTION.
+</trl>
+
+### What Goes In
+
+Function contracts: what it takes, what it returns, what it throws, and any non-obvious obligation. One to three sentences.
+
+### What Stays Out
+
+Trivial functions. A getter, a simple constructor, a one-line utility — these don't need TRL. If the function signature tells the whole story, don't repeat it in TRL.
+
+### When to Write Inline TRL
+
+<trl>
+AGENT SHALL WRITE INLINE RECORD trl_block IF FUNCTION 'is PUBLIC.
+AGENT SHALL WRITE INLINE RECORD trl_block IF FUNCTION CONTAINS RECORD side_effect.
+AGENT SHALL WRITE INLINE RECORD trl_block IF FUNCTION CONTAINS RECORD security OBLIGATION.
+AGENT SHALL WRITE INLINE RECORD trl_block IF FUNCTION CONTAINS RECORD retry OR RECORD timeout.
+AGENT MAY SKIP INLINE RECORD trl_block IF FUNCTION 'is PRIVATE AND TRIVIAL.
+</trl>
+
+### Example
+
+```python
+# <trl>FUNCTION validate_token SHALL VALIDATE DATA token SUBJECT_TO INTERFACE jwt_schema.
+#   IF DATA token 'is INVALID OR EXPIRED THEN THROW EXCEPTION auth_error.
+#   FUNCTION validate_token SHALL RETURN PARTY user 'with ACTIVE ACCESS.</trl>
+def validate_token(token: str) -> User:
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=["HS256"])
+    except jwt.ExpiredSignatureError:
+        raise AuthError("Token expired")
+    except jwt.InvalidTokenError:
+        raise AuthError("Invalid token")
+    return User.from_payload(payload)
+
+
+# <trl>FUNCTION send_welcome SHALL SEND MESSAGE welcome TO PARTY user
+#   THEN WRITE RECORD log. FUNCTION send_welcome SHALL RETRY BOUNDED 3.</trl>
+def send_welcome(user: User):
+    for attempt in range(3):
+        try:
+            email.send(user.email, WELCOME_TEMPLATE)
+            logger.info(f"Welcome sent to {user.id}")
+            return
+        except SMTPError:
+            if attempt == 2:
+                raise
+```
+
+---
+
+## The Boundary Rule
+
+<trl>
+DEFINE "boundary" AS ENTRY FILE.
+IF RECORD description 'is ABOVE ENTRY FILE THEN AGENT SHALL USE DATA graph.
+IF RECORD description 'is BELOW ENTRY FILE THEN AGENT SHALL USE RECORD trl_block.
+DATA graph SHALL DESCRIBE RECORD structure — WHAT EXISTS AND HOW IT CONNECTS.
+RECORD trl_block SHALL DESCRIBE RECORD behavior — WHAT MUST HAPPEN AND WHAT MUST NOT.
+</trl>
+
+| Level | Format | Describes | Agent Question |
+|-------|--------|-----------|----------------|
+| System | TRUG graph | Services, databases, top-level modules | What exists? |
+| Component | TRUG graph | Files, classes, public interfaces | What's inside this module? |
+| File header | TRL sentences | Module obligations and prohibitions | What are the contracts? |
+| Inline | TRL sentences | Function contracts and side effects | What does this function guarantee? |
+
+**Above the file: graph. Inside the file: sentences.**
+
+---
+
+## Trugging a Codebase — Step by Step
+
+<trl>
+AGENT SHALL EXECUTE STAGE system THEN STAGE component THEN STAGE file_header THEN STAGE inline.
+AGENT SHALL_NOT EXECUTE STAGE inline 'before STAGE system.
+EACH STAGE SHALL COMPLETE 'before NEXT STAGE BEGINS.
+</trl>
+
+### Step 1: System TRUG
+
+<trl>
+AGENT SHALL READ ALL FILE 'in NAMESPACE project 'at DEPTH 1.
+AGENT SHALL IDENTIFY ALL SERVICE AND STREAM AND MODULE.
+AGENT SHALL CREATE FILE project.trug.json 'with ALL DATA node AND DATA edge.
+AGENT SHALL VALIDATE FILE project.trug.json.
+</trl>
+
+Scan the project root. Identify the big pieces. Create `project.trug.json`. Validate.
+
+### Step 2: Component TRUGs
+
+<trl>
+AGENT SHALL READ EACH MODULE IDENTIFIED 'in STAGE system.
+'for EACH MODULE AGENT SHALL CREATE FILE folder.trug.json.
+AGENT SHALL VALIDATE EACH FILE folder.trug.json.
+</trl>
+
+For each major folder, create a `folder.trug.json`. Map files, public interfaces, imports, calls. Validate.
+
+### Step 3: File Headers
+
+<trl>
+AGENT SHALL READ EACH FILE 'that CONTAINS PUBLIC FUNCTION OR SERVICE.
+'for EACH FILE AGENT SHALL WRITE RECORD trl_block 'at ENTRY FILE.
+AGENT SHALL ASSERT RECORD trl_block CONTAINS RECORD obligation OR RECORD prohibition.
+</trl>
+
+For each non-trivial file, write a `<trl>` header. Cover obligations, prohibitions, interfaces, error contracts.
+
+### Step 4: Inline TRL
+
+<trl>
+AGENT SHALL READ EACH PUBLIC FUNCTION AND EACH CRITICAL FUNCTION.
+'for EACH FUNCTION AGENT SHALL WRITE INLINE RECORD trl_block.
+AGENT MAY SKIP TRIVIAL FUNCTION.
+</trl>
+
+For each public or critical function, write an inline `<trl>` comment. Cover inputs, outputs, exceptions, side effects.
+
+---
+
+## Maintaining TRUGs
+
+<trl>
+IF AGENT CREATE FILE THEN AGENT SHALL UPDATE FILE folder.trug.json.
+IF AGENT DELETE FILE THEN AGENT SHALL UPDATE FILE folder.trug.json.
+IF AGENT CREATE SERVICE OR MODULE THEN AGENT SHALL UPDATE FILE project.trug.json.
+IF AGENT MODIFY RECORD contract 'of FUNCTION THEN AGENT SHALL UPDATE INLINE RECORD trl_block.
+AGENT SHALL_NOT MODIFY RECORD trl_block WITHOUT MODIFYING RECORD code OR RECORD code WITHOUT MODIFYING RECORD trl_block.
+</trl>
+
+TRUGs and TRL stay in sync with code. When code changes, the description changes. When the description changes, the code changes. Drift between the two is a bug.

--- a/installers/pip/src/trugs_agent/templates/TRUGGING/EXAMPLE_auth_module.md
+++ b/installers/pip/src/trugs_agent/templates/TRUGGING/EXAMPLE_auth_module.md
@@ -1,0 +1,110 @@
+# Trugging Example: Auth Module
+
+A walkthrough of the 4-level Trugging methodology applied to an authentication module.
+
+---
+
+## Level 1: System TRUG — `project.trug.json`
+
+The auth module appears as one node in the system graph:
+
+```json
+{
+  "id": "auth",
+  "type": "MODULE",
+  "properties": {"name": "Auth Module", "language": "python"},
+  "parent_id": "api",
+  "contains": [],
+  "metric_level": "HECTO_MODULE",
+  "dimension": "system"
+}
+```
+
+Edges connect it to the rest of the system:
+
+```json
+{"from_id": "api", "to_id": "auth", "relation": "DEPENDS_ON"},
+{"from_id": "auth", "to_id": "db", "relation": "READS"}
+```
+
+**What an LLM learns:** auth exists, the API depends on it, it reads from the database.
+
+---
+
+## Level 2: Component TRUG — `auth/folder.trug.json`
+
+Inside the auth folder, each file and public interface is a node:
+
+```json
+{
+  "nodes": [
+    {"id": "handler", "type": "FILE", "properties": {"path": "handler.py", "purpose": "Request handlers — login, logout, token refresh"}, ...},
+    {"id": "models", "type": "FILE", "properties": {"path": "models.py", "purpose": "User and Token data models"}, ...},
+    {"id": "middleware", "type": "FILE", "properties": {"path": "middleware.py", "purpose": "Auth middleware — validates JWT on every request"}, ...},
+    {"id": "UserService", "type": "SERVICE", "properties": {"name": "UserService"}, "parent_id": "handler", ...},
+    {"id": "AuthMiddleware", "type": "FUNCTION", "properties": {"name": "AuthMiddleware"}, "parent_id": "middleware", ...}
+  ],
+  "edges": [
+    {"from_id": "handler", "to_id": "models", "relation": "IMPORTS"},
+    {"from_id": "middleware", "to_id": "models", "relation": "IMPORTS"},
+    {"from_id": "UserService", "to_id": "AuthMiddleware", "relation": "DEPENDS_ON"}
+  ]
+}
+```
+
+**What an LLM learns:** three files, how they import each other, UserService depends on AuthMiddleware.
+
+---
+
+## Level 3: File Header TRL — top of `auth/handler.py`
+
+```python
+# <trl>
+# MODULE auth SHALL AUTHENTICATE ALL PARTY 'before GRANT ACCESS TO DATA.
+# MODULE auth SHALL READ DATA credential FROM ENDPOINT environment_variable.
+# MODULE auth SHALL_NOT WRITE DATA credential TO FILE OR STREAM log.
+# MODULE auth SHALL VALIDATE DATA token SUBJECT_TO INTERFACE jwt_schema
+#   THEN RETURN PARTY user OR THROW EXCEPTION auth_error.
+# IF DATA token 'is EXPIRED THEN MODULE auth SHALL DENY PARTY
+#   AND SEND ERROR TO PARTY caller.
+# </trl>
+
+import jwt
+from config import SECRET_KEY
+from models import User
+```
+
+**What an LLM learns:** 5 obligations and prohibitions — authenticate before access, read creds from env vars, never log secrets, validate tokens or throw, handle expiration. All in 5 sentences.
+
+---
+
+## Level 4: Inline TRL — on `validate_token` function
+
+```python
+# <trl>FUNCTION validate_token SHALL VALIDATE DATA token SUBJECT_TO INTERFACE jwt_schema.
+#   IF DATA token 'is INVALID OR EXPIRED THEN THROW EXCEPTION auth_error.
+#   FUNCTION validate_token SHALL RETURN PARTY user 'with ACTIVE ACCESS.</trl>
+def validate_token(token: str) -> User:
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=["HS256"])
+    except jwt.ExpiredSignatureError:
+        raise AuthError("Token expired")
+    except jwt.InvalidTokenError:
+        raise AuthError("Invalid token")
+    return User.from_payload(payload)
+```
+
+**What an LLM learns:** this function's contract — validate JWT, throw on invalid/expired, return User. Can verify code matches, generate tests, detect drift.
+
+---
+
+## The Walkthrough
+
+An LLM fixing a bug in auth reads 4 things:
+
+1. `project.trug.json` → auth exists, API depends on it, it reads from DB
+2. `auth/folder.trug.json` → handler.py, models.py, middleware.py, their imports
+3. `auth/handler.py` header TRL → module obligations: authenticate, never log secrets, handle expiration
+4. Inline TRL on `validate_token` → function contract: validate JWT, throw on expired, return User
+
+System to function in 4 reads. No prose docs, no guessing, no asking.

--- a/installers/pip/src/trugs_agent/templates/TRUGGING/README.md
+++ b/installers/pip/src/trugs_agent/templates/TRUGGING/README.md
@@ -1,0 +1,52 @@
+# TRUGGING — How to Describe a Program with TRUGs and TRL
+
+Trugging is the methodology for describing a codebase at every level of granularity — from the whole system down to a single function. TRUGs (graphs) describe structure. TRL (sentences) describe behavior. Together they give an LLM a complete, machine-readable picture of your program without reading every line of code.
+
+## When to Use
+
+Any codebase that an LLM will work on repeatedly. The upfront cost is small — a JSON file per major folder, a few sentences per file. The payoff is that your LLM stops guessing architecture and starts navigating it.
+
+## Four Levels
+
+### Level 1: System — `project.trug.json`
+
+The whole program as a graph. Nodes are services, databases, external APIs, major modules. Edges are dependencies, data flows, ownership.
+
+Your LLM reads this to answer: *what exists and what connects to what?*
+
+### Level 2: Component — `folder.trug.json`
+
+Each major folder gets its own graph. Nodes are files, classes, key interfaces. Edges are imports, implementations, calls.
+
+Your LLM reads this to answer: *what's inside this module and how do the pieces fit together?*
+
+### Level 3: File Header — `<trl>` block at top of file
+
+A few TRL sentences describing what the module does, what it must do, and what it must not do. Obligations, not implementation details.
+
+Your LLM reads this to answer: *what are this module's contracts?*
+
+### Level 4: Inline — `<trl>` in code comments
+
+TRL sentences on critical functions or blocks. Compilable contracts that an LLM can verify against the code, generate tests from, or detect drift on.
+
+Your LLM reads this to answer: *what is this function's exact contract?*
+
+## The Boundary Rule
+
+Above the file boundary (system, folder): **use TRUGs**. You're mapping structure — things and relationships. Machines traverse it.
+
+Inside the file boundary (header, inline): **use TRL**. You're specifying behavior — actions and obligations. Humans read it, agents execute it.
+
+**TRUGs are nouns. TRL is verbs.**
+
+## Example Walkthrough
+
+An agent needs to fix a bug in the auth module:
+
+1. Reads `project.trug.json` — finds `auth`, sees it connects to `api` and `db`
+2. Reads `auth/folder.trug.json` — finds `handler.py`, `models.py`, sees `UserService` depends on `TokenValidator`
+3. Reads `auth/handler.py` header TRL — knows: must authenticate, must not log secrets, must handle expiration
+4. Reads inline TRL on `validate_token` — knows the function contract: validate JWT, throw on expired, return User
+
+Four reads. System to function. No prose docs, no guessing, no asking the human.

--- a/installers/pip/src/trugs_agent/templates/WEB_HUB/AGENT.md
+++ b/installers/pip/src/trugs_agent/templates/WEB_HUB/AGENT.md
@@ -1,0 +1,142 @@
+# WEB_HUB — Agent Instructions
+
+<trl>
+DEFINE "WEB_HUB" AS DATA graph 'for RECORD web_resource.
+EACH DATA node SHALL CONTAIN RECORD url AND RECORD purpose AND RECORD category.
+EACH DATA edge SHALL CONTAIN RECORD relation AND RECORD weight FROM 0.0 TO 1.0.
+AGENT SHALL READ DATA graph WEB_HUB TO NAVIGATE RECORD web_landscape.
+AGENT SHALL_NOT FETCH RECORD url UNLESS RECORD purpose MATCHES RECORD task.
+</trl>
+
+A WEB_HUB is a TRUG that indexes web resources — papers, repos, tools, articles, standards — organized into branches with weighted edges showing how things relate.
+
+---
+
+## Structure
+
+<trl>
+DEFINE "branch" AS MODULE CONTAINING RESOURCE node 'for A RECORD audience.
+EACH DATA graph WEB_HUB SHALL CONTAIN ONE OR MORE MODULE branch.
+EACH MODULE branch SHALL CONTAIN RESOURCE node 'with RECORD url AND RECORD purpose.
+DATA edge 'between RESOURCE SHALL CONTAIN RECORD weight AND RECORD relation.
+RECORD weight SHALL RANK RECORD relevance — HIGHER 'is MORE RELEVANT.
+</trl>
+
+A web hub has three levels:
+
+| Level | Type | Purpose |
+|-------|------|---------|
+| Root | FOLDER | The hub itself — contains branches |
+| Branch | MODULE | Audience-specific grouping of resources |
+| Resource | RESOURCE | A single URL with purpose and category |
+
+### Resource Node Properties
+
+<trl>
+EACH RESOURCE node SHALL CONTAIN RECORD name — TITLE 'of RESOURCE.
+EACH RESOURCE node SHALL CONTAIN RECORD url — EXACT RECORD address.
+EACH RESOURCE node SHALL CONTAIN RECORD purpose — A RECORD sentence EXPLAINING WHAT RESOURCE CONTAINS AND WHY IT MATTERS.
+EACH RESOURCE node SHALL CONTAIN RECORD category — PAPER OR REPO OR ARTICLE OR TOOL OR STANDARD OR GUIDE OR TEMPLATE OR INFLUENCER.
+</trl>
+
+The `purpose` field is the key — it tells you what the resource contains without fetching it. Read purposes to decide relevance before opening any URL.
+
+---
+
+## Edge Relations
+
+<trl>
+DEFINE "MOTIVATES" AS DATA edge — THIS RESOURCE IDENTIFIES A RECORD problem 'that TARGET SOLVES.
+DEFINE "CONTRASTS" AS DATA edge — THIS RESOURCE DOES RECORD similar_thing BUT DIFFERENTLY.
+DEFINE "COMPLEMENTS" AS DATA edge — THIS RESOURCE WORKS ALONGSIDE TARGET.
+DEFINE "CONTEXTUALIZES" AS DATA edge — THIS RESOURCE SHOWS THE RECORD landscape.
+DEFINE "EXTENDS" AS DATA edge — THIS RESOURCE BUILDS 'on TARGET.
+DEFINE "AMPLIFIES" AS DATA edge — THIS RESOURCE INCREASES RECORD reach 'of TARGET.
+DEFINE "IMPLEMENTS" AS DATA edge — THIS RESOURCE 'is AN IMPLEMENTATION 'of TARGET.
+DEFINE "FEEDS" AS DATA edge — BRANCH CONVERGES 'on TARGET.
+</trl>
+
+| Relation | Weight Range | Meaning |
+|----------|-------------|---------|
+| MOTIVATES | 0.6–0.95 | Resource identifies the problem your project solves |
+| CONTRASTS | 0.5–0.8 | Resource does something similar but different — competitive landscape |
+| COMPLEMENTS | 0.5–0.85 | Resource works alongside yours — integration opportunity |
+| CONTEXTUALIZES | 0.5–0.7 | Resource shows the broader landscape |
+| EXTENDS | 0.7–0.9 | Resource builds on another resource |
+| AMPLIFIES | 0.8–0.9 | Resource increases reach — influencers, channels |
+| IMPLEMENTS | 0.9–1.0 | Resource is a concrete implementation of a spec or paper |
+| FEEDS | 1.0 | Branch → convergence node (structural) |
+
+**Higher weight = stronger connection.** When traversing, follow high-weight edges first.
+
+---
+
+## How to Read a Web Hub
+
+<trl>
+AGENT SHALL READ DATA graph web.trug.json 'at ENTRY RECORD research_task.
+AGENT SHALL IDENTIFY ALL MODULE branch TO UNDERSTAND RECORD landscape_structure.
+AGENT SHALL FOLLOW DATA edge 'with RECORD weight ABOVE 0.8 FIRST.
+AGENT SHALL READ RECORD purpose 'on EACH RESOURCE 'before FETCH RECORD url.
+AGENT SHALL_NOT FETCH ALL RESOURCE — ONLY FETCH RECORD relevant RESOURCE.
+</trl>
+
+1. **Read the branches** — understand how resources are organized by audience
+2. **Follow high-weight edges** — these are the strongest connections
+3. **Read purposes** — decide relevance before fetching any URL
+4. **Traverse by relation type** — MOTIVATES edges find the problem, CONTRASTS edges find alternatives, COMPLEMENTS edges find integration partners
+
+---
+
+## How to Build a Web Hub
+
+<trl>
+AGENT SHALL IDENTIFY RECORD audience 'for EACH MODULE branch.
+'for EACH MODULE branch AGENT SHALL RESEARCH 10 TO 20 RESOURCE.
+EACH RESOURCE SHALL 'have RECORD url 'that EXISTS AND RECORD purpose 'that 'is SPECIFIC.
+AGENT SHALL CREATE DATA edge 'with RECORD weight 'for EACH RECORD relationship 'between RESOURCE.
+AGENT SHALL VALIDATE DATA graph web.trug.json.
+</trl>
+
+### Step by Step
+
+1. **Define branches** — who are the audiences? What pain point brings each audience to your project?
+2. **Research resources** — for each branch, find 10-20 high-quality resources: papers, repos, tools, articles, standards
+3. **Write purposes** — one sentence per resource explaining what it contains AND why it matters to your project
+4. **Create edges** — how do resources relate to each other and to your project? Weight by relevance
+5. **Validate** — run the validator to check graph correctness
+
+### Resource Categories
+
+<trl>
+DEFINE "PAPER" AS RECORD category — ACADEMIC RESEARCH OR TECHNICAL REPORT.
+DEFINE "REPO" AS RECORD category — GITHUB REPOSITORY OR CODE PROJECT.
+DEFINE "ARTICLE" AS RECORD category — BLOG POST OR TECHNICAL ARTICLE.
+DEFINE "TOOL" AS RECORD category — SOFTWARE TOOL OR GENERATOR.
+DEFINE "STANDARD" AS RECORD category — FORMAL STANDARD OR SPECIFICATION.
+DEFINE "GUIDE" AS RECORD category — HOWTO OR BEST PRACTICES.
+DEFINE "TEMPLATE" AS RECORD category — REUSABLE STARTING POINT.
+DEFINE "INFLUENCER" AS RECORD category — PERSON OR CHANNEL 'with RECORD audience.
+</trl>
+
+---
+
+## Updating a Web Hub
+
+<trl>
+IF AGENT DISCOVER RELEVANT RECORD web_resource THEN AGENT MAY ADD RESOURCE node.
+EACH NEW RESOURCE node SHALL CONTAIN RECORD url AND RECORD purpose AND RECORD category.
+AGENT SHALL CREATE DATA edge 'with RECORD weight TO EXISTING RESOURCE OR MODULE.
+AGENT SHALL_NOT ADD RESOURCE WITHOUT RECORD purpose — PURPOSE 'is REQUIRED.
+AGENT SHALL VALIDATE DATA graph AFTER EACH UPDATE.
+</trl>
+
+- **New resource found** — add a RESOURCE node with url, purpose, category. Create edges to related resources.
+- **Resource gone** — set `stale: true` on the node. Don't remove it — the edges still show the relationship.
+- **Better resource found** — add the new one, create an `SUPERSEDES` edge to the old one.
+
+---
+
+## Example
+
+See the main `web.trug.json` in this folder — 3 branches (Structured Agent, Graph Native, Agent Protocols), 54 nodes, 51 edges, 10 relation types. Also see `NDA/web.trug.json` for a domain-specific example (NDA research — templates, legal guidance, tools, WA state statutes).

--- a/installers/pip/src/trugs_agent/templates/WEB_HUB/README.md
+++ b/installers/pip/src/trugs_agent/templates/WEB_HUB/README.md
@@ -1,0 +1,27 @@
+# WEB_HUB — Curated Web Resource Graph
+
+A TRUG graph that indexes the web landscape around TRUGS-AGENT. Nodes are URLs — papers, repos, tools, articles, standards. Edges show how they relate. Weights rank importance.
+
+## Three Branches
+
+| Branch | Audience | Entry Point |
+|--------|----------|-------------|
+| **Structured Agent** | LLM developers frustrated with prompt drift | TRL + TRUGGING |
+| **Graph Native** | Engineers building with knowledge graphs and code graphs | FOLDER + TRUGGING |
+| **Agent Protocols** | Teams building reliable agent systems | AAA + MEMORY + EPIC |
+
+All three branches converge on TRUGS-AGENT — each audience discovers it through their own pain point.
+
+## How to Use
+
+Your LLM reads `web.trug.json` to navigate the landscape:
+- Find related work for a blog post
+- Pull citations for a paper
+- Answer "what's the state of the art in X?"
+- Identify gaps where TRUGS-AGENT is the only solution
+
+Edge weights (0.0–1.0) rank relevance to the TRUGS-AGENT story. Higher weight = stronger connection.
+
+## Structure
+
+`web.trug.json` contains three branch nodes, each containing 12-18 resource nodes. Resources link to each other and to TRUGS-AGENT components via weighted edges.

--- a/installers/pip/src/trugs_agent/templates/WEB_HUB/web.trug.json
+++ b/installers/pip/src/trugs_agent/templates/WEB_HUB/web.trug.json
@@ -1,0 +1,842 @@
+{
+  "name": "TRUGS-AGENT Web Hub",
+  "version": "1.0.0",
+  "type": "WEB_HUB",
+  "description": "Curated web resource graph — 3 branches, 50+ resources, weighted edges converging on TRUGS-AGENT",
+  "dimensions": {
+    "web_landscape": {
+      "description": "Web resources organized by audience and relevance to TRUGS-AGENT",
+      "base_level": "BASE"
+    }
+  },
+  "capabilities": {
+    "extensions": [],
+    "vocabularies": ["project_v1"],
+    "profiles": []
+  },
+  "nodes": [
+    {
+      "id": "hub_root",
+      "type": "FOLDER",
+      "properties": {
+        "name": "TRUGS-AGENT Web Hub",
+        "purpose": "Three-branch curated graph of web resources converging on TRUGS-AGENT adoption"
+      },
+      "parent_id": null,
+      "contains": ["branch_structured_agent", "branch_graph_native", "branch_agent_protocols", "convergence_trugs_agent", "convergence_trugs_spec", "convergence_trugs_paper", "convergence_natebjones", "convergence_natebjones_yt"],
+      "metric_level": "KILO_FOLDER",
+      "dimension": "web_landscape"
+    },
+
+    {
+      "id": "convergence_trugs_agent",
+      "type": "ENDPOINT",
+      "properties": {
+        "name": "TRUGS-AGENT Repository",
+        "url": "https://github.com/TRUGS-LLC/TRUGS-AGENT",
+        "purpose": "The product — one file teaches your LLM TRL, AAA, Memory, EPIC, Folder indexing, and Trugging",
+        "category": "REPO"
+      },
+      "parent_id": "hub_root",
+      "contains": [],
+      "metric_level": "HECTO_ENDPOINT",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "convergence_trugs_spec",
+      "type": "ENDPOINT",
+      "properties": {
+        "name": "TRUGS Specification Repository",
+        "url": "https://github.com/TRUGS-LLC/TRUGS",
+        "purpose": "Full TRL + TRUGS specification — 190-word vocabulary, CORE rules, validator, the complete formal system",
+        "category": "REPO"
+      },
+      "parent_id": "hub_root",
+      "contains": [],
+      "metric_level": "HECTO_ENDPOINT",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "convergence_trugs_paper",
+      "type": "ENDPOINT",
+      "properties": {
+        "name": "TRUGS Paper (Zenodo DOI)",
+        "url": "https://doi.org/10.5281/zenodo.19379454",
+        "purpose": "Academic paper — TRUGS specification, TRL compilation algorithm, graph-sentence equivalence proof",
+        "category": "PAPER"
+      },
+      "parent_id": "hub_root",
+      "contains": [],
+      "metric_level": "HECTO_ENDPOINT",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "convergence_natebjones",
+      "type": "ENDPOINT",
+      "properties": {
+        "name": "Nate B Jones",
+        "url": "https://natebjones.com",
+        "purpose": "Tech creator with 500K+ audience — potential TRUGS-AGENT evangelist and adoption channel",
+        "category": "INFLUENCER"
+      },
+      "parent_id": "hub_root",
+      "contains": [],
+      "metric_level": "HECTO_ENDPOINT",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "convergence_natebjones_yt",
+      "type": "ENDPOINT",
+      "properties": {
+        "name": "Nate B Jones — YouTube",
+        "url": "https://www.youtube.com/@NateBJones",
+        "purpose": "YouTube channel — AI/dev tooling content reaching 500K+ audience, video format for TRUGS-AGENT demos",
+        "category": "INFLUENCER"
+      },
+      "parent_id": "hub_root",
+      "contains": [],
+      "metric_level": "HECTO_ENDPOINT",
+      "dimension": "web_landscape"
+    },
+
+    {
+      "id": "branch_structured_agent",
+      "type": "MODULE",
+      "properties": {
+        "name": "Structured Agent Instructions",
+        "purpose": "Branch 1 — the problem of prompt ambiguity and solutions for formalized LLM instructions",
+        "audience": "LLM developers frustrated with prompt drift",
+        "converges_on": "TRL + TRUGGING"
+      },
+      "parent_id": "hub_root",
+      "contains": ["sa_specs_paper", "sa_prompt_report", "sa_ifeval", "sa_goal_drift", "sa_lmql_paper", "sa_agentif", "sa_dspy", "sa_guidance", "sa_lmql", "sa_typechat", "sa_outlines", "sa_instructor", "sa_json_prompting", "sa_anthropic_prompting", "sa_llmops_2025"],
+      "metric_level": "HECTO_MODULE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_specs_paper",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Specifications: The Missing Link to Making LLM Systems an Engineering Discipline",
+        "url": "https://arxiv.org/abs/2412.05299",
+        "purpose": "UC Berkeley paper arguing that precise specification of expected behavior is the missing foundation for reliable LLM systems — the exact problem TRL solves",
+        "category": "PAPER",
+        "authors": "Ion Stoica, Matei Zaharia et al."
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_prompt_report",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "The Prompt Report: A Systematic Survey of Prompting Techniques",
+        "url": "https://arxiv.org/abs/2406.06608",
+        "purpose": "76-page survey covering 58 text prompting techniques from 1,500+ papers — the landscape TRL simplifies to 190 words",
+        "category": "PAPER",
+        "authors": "Schulhoff et al. (OpenAI, Microsoft, Google, Stanford)"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_ifeval",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "IFEval: Instruction-Following Evaluation for Large Language Models",
+        "url": "https://arxiv.org/abs/2311.07911",
+        "purpose": "Google Research benchmark with 25 verifiable instruction types and ~500 test prompts measuring LLM compliance with precise constraints",
+        "category": "PAPER",
+        "authors": "Jeffrey Zhou et al."
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_goal_drift",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Evaluating Goal Drift in Language Model Agents",
+        "url": "https://arxiv.org/html/2505.02709v1",
+        "purpose": "Quantifies how LLM agents progressively deviate from original instructions during long-context interactions — the drift TRL prevents",
+        "category": "PAPER"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_lmql_paper",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Prompting Is Programming: A Query Language for Large Language Models",
+        "url": "https://arxiv.org/abs/2212.06094",
+        "purpose": "ETH Zurich paper proposing prompting-as-programming with constraints and types — TRL takes this further with a fixed vocabulary that compiles to graphs",
+        "category": "PAPER",
+        "authors": "Beurer-Kellner et al."
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_agentif",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "AGENTIF: Benchmarking Instruction Following of LLMs as Agents",
+        "url": "https://keg.cs.tsinghua.edu.cn/persons/xubin/papers/AgentIF.pdf",
+        "purpose": "Tsinghua benchmark finding even GPT-4 achieves only ~80% on simple unambiguous instructions — motivates formalized instruction languages",
+        "category": "PAPER"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_dspy",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "DSPy — Programming, Not Prompting, Language Models",
+        "url": "https://github.com/stanfordnlp/dspy",
+        "purpose": "Stanford framework replacing brittle prompts with composable Python modules — structured generation without a fixed vocabulary",
+        "category": "TOOL"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_guidance",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Guidance — Token-Level LLM Output Control",
+        "url": "https://github.com/guidance-ai/guidance",
+        "purpose": "Controls LLM output via Python-embedded grammars and CFGs — structural constraints at inference layer, not post-hoc",
+        "category": "TOOL"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_lmql",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "LMQL — Query Language for LLMs",
+        "url": "https://github.com/eth-sri/lmql",
+        "purpose": "SQL-like declarative constraints for LLMs — typed output specifications and multi-variable templates",
+        "category": "TOOL"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_typechat",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "TypeChat — Schema Engineering for LLMs",
+        "url": "https://github.com/microsoft/TypeChat",
+        "purpose": "Microsoft tool replacing prompt engineering with TypeScript schema engineering — validates responses against types",
+        "category": "TOOL"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_outlines",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Outlines — Structured Generation via FSMs",
+        "url": "https://github.com/dottxt-ai/outlines",
+        "purpose": "Compiles JSON schemas and regex into finite state machines for guaranteed-valid LLM output during token generation",
+        "category": "TOOL"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_instructor",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Instructor — Pydantic-Based Structured LLM Output",
+        "url": "https://github.com/567-labs/instructor",
+        "purpose": "Pydantic validation for LLM responses with automatic retries — available in Python, TypeScript, Go, Ruby, Rust, Elixir",
+        "category": "TOOL"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_json_prompting",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Structured Prompting with JSON: The Engineering Path to Reliable LLMs",
+        "url": "https://medium.com/@vishal.dutt.data.architect/structured-prompting-with-json-the-engineering-path-to-reliable-llms-2c0cb1b767cf",
+        "purpose": "Introduces the 'Ambiguity Tax' concept — operational cost of vague prompts, reports 99%+ schema adherence with structured JSON prompting",
+        "category": "ARTICLE"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_anthropic_prompting",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Anthropic — Claude Prompting Best Practices",
+        "url": "https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices",
+        "purpose": "Official Anthropic guide recommending XML-tagged structure, role-based system prompts, and schema-first design",
+        "category": "ARTICLE"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "sa_llmops_2025",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "What 1,200 Production Deployments Reveal About LLMOps in 2025",
+        "url": "https://www.zenml.io/blog/what-1200-production-deployments-reveal-about-llmops-in-2025",
+        "purpose": "Production retrospective marking the shift from prompt engineering to context engineering — architecting structured information, not tweaking wording",
+        "category": "ARTICLE"
+      },
+      "parent_id": "branch_structured_agent",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+
+    {
+      "id": "branch_graph_native",
+      "type": "MODULE",
+      "properties": {
+        "name": "Graph-Native Development",
+        "purpose": "Branch 2 — using graphs to describe, index, and navigate codebases and knowledge",
+        "audience": "Engineers building with knowledge graphs and code graphs",
+        "converges_on": "FOLDER + TRUGGING"
+      },
+      "parent_id": "hub_root",
+      "contains": ["gn_kg_survey", "gn_kg_evolution", "gn_llm_kg_construction", "gn_neo4j", "gn_networkx", "gn_joern", "gn_treesitter_graph", "gn_emerge", "gn_code_property_graph", "gn_neo4j_codebase", "gn_dependency_graphs", "gn_software_dep_graph", "gn_graph4code", "gn_jsonld", "gn_gql"],
+      "metric_level": "HECTO_MODULE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_kg_survey",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Knowledge Graphs: Opportunities and Challenges",
+        "url": "https://link.springer.com/article/10.1007/s10462-023-10465-9",
+        "purpose": "Comprehensive survey covering KG construction, embedding, reasoning, and applications — the academic foundation for graph-based systems",
+        "category": "PAPER"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_kg_evolution",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "On the Evolution of Knowledge Graphs: A Survey and Perspective",
+        "url": "https://arxiv.org/abs/2310.04835",
+        "purpose": "Covers static, dynamic, temporal, and event knowledge graphs with extraction and reasoning techniques",
+        "category": "PAPER"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_llm_kg_construction",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "LLM-Empowered Knowledge Graph Construction: A Survey",
+        "url": "https://arxiv.org/abs/2510.20345",
+        "purpose": "How LLMs reshape the KG construction pipeline from ontology engineering through knowledge fusion — TRUGS automates this for codebases",
+        "category": "PAPER"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_neo4j",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Neo4j — Graph Database",
+        "url": "https://github.com/neo4j/neo4j",
+        "purpose": "Leading open-source property graph database with ACID transactions and Cypher query language — the heavyweight; TRUGS is the lightweight JSON alternative",
+        "category": "REPO"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_networkx",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "NetworkX — Network Analysis in Python",
+        "url": "https://github.com/networkx/networkx",
+        "purpose": "Python library for graph creation, manipulation, and analysis — computation engine, not a specification format",
+        "category": "REPO"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_joern",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Joern — Code Analysis via Code Property Graphs",
+        "url": "https://github.com/joernio/joern",
+        "purpose": "Code analysis platform for C/C++/Java/Python/JS based on code property graphs — analyzes code as graphs, TRUGS indexes projects as graphs",
+        "category": "REPO"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_treesitter_graph",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "tree-sitter-graph — DSL for Graph Construction from Source Code",
+        "url": "https://github.com/tree-sitter/tree-sitter-graph",
+        "purpose": "Rust DSL for constructing arbitrary graph structures from parsed source code — AST to graph, bottom-up",
+        "category": "REPO"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_emerge",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Emerge — Interactive Codebase Visualization",
+        "url": "https://github.com/glato/emerge",
+        "purpose": "Browser-based dependency visualization with graph metrics — visual where TRUGS is structural",
+        "category": "REPO"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_code_property_graph",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Code Property Graph — Specification and Query Language",
+        "url": "https://github.com/ShiftLeftSecurity/codepropertygraph",
+        "purpose": "Formal spec of the code property graph data structure — security-focused code graph, TRUGS is project-focused",
+        "category": "REPO"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_neo4j_codebase",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Codebase Knowledge Graph: Code Analysis with Graphs",
+        "url": "https://neo4j.com/blog/developer/codebase-knowledge-graph/",
+        "purpose": "Neo4j blog demonstrating Cypher queries for structural code analysis — heavy tooling, TRUGS does it with one JSON file",
+        "category": "ARTICLE"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_dependency_graphs",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Safely Restructure Your Codebase with Dependency Graphs",
+        "url": "https://understandlegacycode.com/blog/safely-restructure-codebase-with-dependency-graphs/",
+        "purpose": "Practical guide to using dependency graphs for safe refactoring of legacy codebases",
+        "category": "ARTICLE"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_software_dep_graph",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Software Dependency Graphs: Definition, Use Cases, and Implementation",
+        "url": "https://www.puppygraph.com/blog/software-dependency-graph",
+        "purpose": "Overview of how dependency graphs represent file/class/function/library relationships in codebases",
+        "category": "ARTICLE"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_graph4code",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "GraphGen4Code — Code Knowledge Graph Toolkit",
+        "url": "https://wala.github.io/graph4code/",
+        "purpose": "IBM toolkit for building code knowledge graphs powering program search, code understanding, and bug detection",
+        "category": "TOOL"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_jsonld",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "JSON-LD 1.1 — W3C Recommendation",
+        "url": "https://www.w3.org/TR/json-ld11/",
+        "purpose": "W3C standard for encoding linked/graph data in JSON — bridges JSON simplicity with RDF expressiveness. TRUGS is simpler: no @context, no namespaces",
+        "category": "STANDARD"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "gn_gql",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "GQL — Graph Query Language (ISO/IEC 39075:2024)",
+        "url": "https://www.gqlstandards.org/",
+        "purpose": "First new ISO database query language in 35+ years — complete DML/DDL for property graphs. TRUGS is a format, not a query language",
+        "category": "STANDARD"
+      },
+      "parent_id": "branch_graph_native",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+
+    {
+      "id": "branch_agent_protocols",
+      "type": "MODULE",
+      "properties": {
+        "name": "LLM Agent Protocols",
+        "purpose": "Branch 3 — development workflows, memory systems, and reliability patterns for LLM-powered agents",
+        "audience": "Teams building reliable agent systems",
+        "converges_on": "AAA + MEMORY + EPIC"
+      },
+      "parent_id": "hub_root",
+      "contains": ["ap_planning_survey", "ap_memory_survey", "ap_agentic_reasoning", "ap_autonomous_agents", "ap_anthropic_auditing", "ap_langgraph", "ap_crewai", "ap_autogen", "ap_openhands", "ap_claude_code_action", "ap_building_agents", "ap_claude_agent_sdk", "ap_year_in_llms", "ap_promptfoo", "ap_awesome_memory"],
+      "metric_level": "HECTO_MODULE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_planning_survey",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Understanding the Planning of LLM Agents: A Survey",
+        "url": "https://arxiv.org/abs/2402.02716",
+        "purpose": "Survey of planning in LLM agents — task decomposition, multi-step reasoning, replanning. AAA is a fixed 9-phase plan that removes the need for ad-hoc planning",
+        "category": "PAPER"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_memory_survey",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Memory for Autonomous LLM Agents: Mechanisms, Evaluation, and Frontiers",
+        "url": "https://arxiv.org/html/2603.07670",
+        "purpose": "Survey of agent memory architectures — episodic, semantic, procedural. TRUGS Memory is simpler: 4 types, markdown files, MEMORY.md index",
+        "category": "PAPER"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_agentic_reasoning",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Agentic Reasoning for Large Language Models",
+        "url": "https://arxiv.org/abs/2601.12538",
+        "purpose": "Unified roadmap bridging thought and action in LLM agents — personalization, long-horizon interaction, multi-agent scaling",
+        "category": "PAPER"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_autonomous_agents",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "From LLM Reasoning to Autonomous AI Agents: A Comprehensive Review",
+        "url": "https://arxiv.org/abs/2504.19678",
+        "purpose": "Reviews 2023-2025 agent frameworks integrating LLMs with modular toolkits for autonomous decision-making",
+        "category": "PAPER"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_anthropic_auditing",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Building and Evaluating Alignment Auditing Agents",
+        "url": "https://alignment.anthropic.com/2025/automated-auditing/",
+        "purpose": "Anthropic research on automated agent auditing — the problem AAA Phase 8 solves with spec-defined audit criteria",
+        "category": "PAPER"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_langgraph",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "LangGraph — Build Resilient Language Agents as Graphs",
+        "url": "https://github.com/langchain-ai/langgraph",
+        "purpose": "Stateful multi-step agent workflows as directed graphs with persistence — graph-based execution, not graph-based specification",
+        "category": "REPO"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_crewai",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "CrewAI — Orchestrating Role-Playing Autonomous AI Agents",
+        "url": "https://github.com/crewaiinc/crewai",
+        "purpose": "Multi-agent framework with role-based crews and structured flows — orchestration without formalized instructions",
+        "category": "REPO"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_autogen",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Microsoft AutoGen — Agentic AI Framework",
+        "url": "https://github.com/microsoft/autogen",
+        "purpose": "Multi-agent conversation framework enabling LLM/tool/human integration — agent chat without development protocol",
+        "category": "REPO"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_openhands",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "OpenHands — AI-Driven Software Development Platform",
+        "url": "https://github.com/OpenHands/OpenHands",
+        "purpose": "Open-source coding agent with composable SDK and GitHub issue resolver — execution without plan-before-code protocol",
+        "category": "REPO"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_claude_code_action",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Claude Code Action — GitHub Actions Integration",
+        "url": "https://github.com/anthropics/claude-code-action",
+        "purpose": "Official Anthropic action for Claude Code in CI/CD — autonomous agent in pipelines, uses CLAUDE.md for instructions",
+        "category": "REPO"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_building_agents",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Building Effective Agents",
+        "url": "https://www.anthropic.com/research/building-effective-agents",
+        "purpose": "Anthropic's foundational guide — human-in-the-loop checkpoints, stopping conditions, agents as LLMs in loops with tools. AAA formalizes this into 9 phases.",
+        "category": "ARTICLE"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_claude_agent_sdk",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Building Agents with the Claude Agent SDK",
+        "url": "https://www.anthropic.com/engineering/building-agents-with-the-claude-agent-sdk",
+        "purpose": "Engineering guide on self-evaluating agents that check and improve their own output — three approaches to agent reliability",
+        "category": "ARTICLE"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_year_in_llms",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "2025: The Year in LLMs — Simon Willison",
+        "url": "https://simonwillison.net/2025/Dec/31/the-year-in-llms/",
+        "purpose": "Year-end review covering rise of coding agents (Claude Code, Copilot CLI, OpenHands), IDE integration, autonomous development workflows",
+        "category": "ARTICLE"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_promptfoo",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Promptfoo — CI/CD for LLM Evaluation",
+        "url": "https://www.promptfoo.dev/docs/integrations/ci-cd/",
+        "purpose": "LLM evaluation in CI/CD pipelines with quality gates and automated red-teaming — testing without formalized specs",
+        "category": "TOOL"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    },
+    {
+      "id": "ap_awesome_memory",
+      "type": "RESOURCE",
+      "properties": {
+        "name": "Awesome Memory for Agents — Tsinghua C3I",
+        "url": "https://github.com/TsinghuaC3I/Awesome-Memory-for-Agents",
+        "purpose": "Curated paper collection on agent memory — episodic, semantic, procedural memory mechanisms and persistence strategies",
+        "category": "REPO"
+      },
+      "parent_id": "branch_agent_protocols",
+      "contains": [],
+      "metric_level": "BASE_RESOURCE",
+      "dimension": "web_landscape"
+    }
+  ],
+  "edges": [
+    {"from_id": "branch_structured_agent", "to_id": "convergence_trugs_agent", "relation": "FEEDS", "weight": 1.0, "properties": {"path": "Prompt ambiguity → TRL solves it → TRUGS-AGENT delivers it"}},
+    {"from_id": "branch_graph_native", "to_id": "convergence_trugs_agent", "relation": "FEEDS", "weight": 1.0, "properties": {"path": "Graph tooling → FOLDER indexes it → TRUGS-AGENT delivers it"}},
+    {"from_id": "branch_agent_protocols", "to_id": "convergence_trugs_agent", "relation": "FEEDS", "weight": 1.0, "properties": {"path": "Agent reliability → AAA/Memory/EPIC solve it → TRUGS-AGENT delivers it"}},
+
+    {"from_id": "convergence_trugs_agent", "to_id": "convergence_trugs_spec", "relation": "IMPLEMENTS", "weight": 1.0, "properties": {}},
+    {"from_id": "convergence_trugs_spec", "to_id": "convergence_trugs_paper", "relation": "DESCRIBES", "weight": 0.9, "properties": {}},
+
+    {"from_id": "convergence_natebjones", "to_id": "convergence_trugs_agent", "relation": "AMPLIFIES", "weight": 0.9, "properties": {"channel": "Website — tech content, 500K+ audience"}},
+    {"from_id": "convergence_natebjones_yt", "to_id": "convergence_trugs_agent", "relation": "AMPLIFIES", "weight": 0.9, "properties": {"channel": "YouTube — video demos, broader reach"}},
+    {"from_id": "convergence_natebjones_yt", "to_id": "convergence_natebjones", "relation": "EXTENDS", "weight": 0.8, "properties": {"relationship": "Same creator, video format"}},
+
+    {"from_id": "sa_specs_paper", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.95, "properties": {"connection": "Paper argues specifications are missing — TRL is that specification"}},
+    {"from_id": "sa_goal_drift", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.9, "properties": {"connection": "Drift is the problem — fixed vocabulary prevents it"}},
+    {"from_id": "sa_ifeval", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.8, "properties": {"connection": "Instruction following benchmarks — TRL makes instructions unambiguous"}},
+    {"from_id": "sa_agentif", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.8, "properties": {"connection": "80% compliance on simple instructions — TRL pushes toward 100%"}},
+    {"from_id": "sa_prompt_report", "to_id": "convergence_trugs_agent", "relation": "CONTEXTUALIZES", "weight": 0.7, "properties": {"connection": "58 prompting techniques — TRL replaces all of them with one language"}},
+    {"from_id": "sa_lmql_paper", "to_id": "convergence_trugs_agent", "relation": "CONTEXTUALIZES", "weight": 0.7, "properties": {"connection": "Prompting as programming — TRL takes it further with graph compilation"}},
+
+    {"from_id": "sa_dspy", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.7, "properties": {"difference": "DSPy optimizes prompts automatically — TRL eliminates ambiguity by design"}},
+    {"from_id": "sa_guidance", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.6, "properties": {"difference": "Guidance constrains output tokens — TRL constrains input instructions"}},
+    {"from_id": "sa_typechat", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.6, "properties": {"difference": "TypeChat validates output against schema — TRL validates instructions against vocabulary"}},
+    {"from_id": "sa_outlines", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.5, "properties": {"difference": "Outlines ensures valid output format — TRL ensures valid input specification"}},
+    {"from_id": "sa_instructor", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.5, "properties": {"difference": "Instructor validates responses — TRL validates instructions"}},
+    {"from_id": "sa_lmql", "to_id": "sa_lmql_paper", "relation": "IMPLEMENTS", "weight": 0.9, "properties": {}},
+    {"from_id": "sa_anthropic_prompting", "to_id": "convergence_trugs_agent", "relation": "CONTEXTUALIZES", "weight": 0.6, "properties": {"connection": "Recommends structured prompts — TRL is the most structured prompt"}},
+    {"from_id": "sa_llmops_2025", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.7, "properties": {"connection": "Shift from prompt engineering to context engineering — TRL is the context engineering language"}},
+    {"from_id": "sa_json_prompting", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.6, "properties": {"connection": "Ambiguity Tax concept — TRL eliminates the tax"}},
+
+    {"from_id": "gn_neo4j", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.7, "properties": {"difference": "Neo4j is a database — TRUGS is a specification format. Neo4j requires a server; TRUGS is one JSON file"}},
+    {"from_id": "gn_joern", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.7, "properties": {"difference": "Joern analyzes code as graphs — TRUGS indexes projects as graphs. Different granularity"}},
+    {"from_id": "gn_code_property_graph", "to_id": "gn_joern", "relation": "GOVERNS", "weight": 0.9, "properties": {"relationship": "CPG spec underlies Joern"}},
+    {"from_id": "gn_treesitter_graph", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.6, "properties": {"difference": "tree-sitter-graph builds graphs from ASTs — TRUGS builds graphs from project structure"}},
+    {"from_id": "gn_emerge", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.5, "properties": {"difference": "Emerge visualizes — TRUGS specifies. Different output: visual vs machine-readable"}},
+    {"from_id": "gn_graph4code", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.6, "properties": {"difference": "Graph4Code builds code KGs for search — TRUGS builds project KGs for navigation"}},
+    {"from_id": "gn_jsonld", "to_id": "convergence_trugs_spec", "relation": "CONTRASTS", "weight": 0.7, "properties": {"difference": "JSON-LD links to the semantic web — TRUGS links to nothing external. Simpler: no @context, no namespaces"}},
+    {"from_id": "gn_gql", "to_id": "convergence_trugs_spec", "relation": "CONTRASTS", "weight": 0.6, "properties": {"difference": "GQL queries graphs — TRL describes graphs as sentences. Query language vs specification language"}},
+    {"from_id": "gn_kg_survey", "to_id": "gn_kg_evolution", "relation": "EXTENDS", "weight": 0.8, "properties": {}},
+    {"from_id": "gn_llm_kg_construction", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.8, "properties": {"connection": "LLMs building KGs — TRUGS is the format they build into"}},
+    {"from_id": "gn_neo4j_codebase", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.7, "properties": {"connection": "Shows codebase-as-graph value — TRUGS does it without Neo4j"}},
+    {"from_id": "gn_dependency_graphs", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.6, "properties": {"connection": "Dependency graphs for refactoring — folder.trug.json is the persistent index"}},
+    {"from_id": "gn_networkx", "to_id": "convergence_trugs_spec", "relation": "COMPLEMENTS", "weight": 0.5, "properties": {"relationship": "NetworkX can load and analyze TRUGS graphs"}},
+
+    {"from_id": "ap_building_agents", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.95, "properties": {"connection": "Anthropic's agent patterns — AAA formalizes them into 9 mandatory phases"}},
+    {"from_id": "ap_anthropic_auditing", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.9, "properties": {"connection": "Agent auditing research — AAA Phase 3 defines criteria, Phase 8 executes audit"}},
+    {"from_id": "ap_planning_survey", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.85, "properties": {"connection": "Ad-hoc planning survey — AAA replaces ad-hoc with fixed 9-phase protocol"}},
+    {"from_id": "ap_memory_survey", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.85, "properties": {"connection": "Complex memory architectures — TRUGS Memory is 4 types in markdown files"}},
+    {"from_id": "ap_claude_agent_sdk", "to_id": "convergence_trugs_agent", "relation": "MOTIVATES", "weight": 0.8, "properties": {"connection": "Self-evaluating agents — AAA audit cycle is the formalized version"}},
+
+    {"from_id": "ap_langgraph", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.8, "properties": {"difference": "LangGraph executes workflows as graphs — TRUGS specifies projects as graphs. Runtime vs specification"}},
+    {"from_id": "ap_crewai", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.7, "properties": {"difference": "CrewAI orchestrates multiple agents — TRUGS-AGENT teaches one agent to work correctly"}},
+    {"from_id": "ap_autogen", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.7, "properties": {"difference": "AutoGen enables agent chat — TRUGS-AGENT enables agent discipline"}},
+    {"from_id": "ap_openhands", "to_id": "convergence_trugs_agent", "relation": "CONTRASTS", "weight": 0.7, "properties": {"difference": "OpenHands is a coding platform — TRUGS-AGENT is a methodology that works in any platform"}},
+    {"from_id": "ap_claude_code_action", "to_id": "convergence_trugs_agent", "relation": "COMPLEMENTS", "weight": 0.85, "properties": {"relationship": "Claude Code reads CLAUDE.md — TRUGS-AGENT IS the CLAUDE.md"}},
+
+    {"from_id": "ap_year_in_llms", "to_id": "convergence_trugs_agent", "relation": "CONTEXTUALIZES", "weight": 0.6, "properties": {"connection": "Landscape overview — shows the ecosystem TRUGS-AGENT operates in"}},
+    {"from_id": "ap_promptfoo", "to_id": "convergence_trugs_agent", "relation": "COMPLEMENTS", "weight": 0.6, "properties": {"relationship": "Promptfoo tests LLM output — TRL makes the input testable too"}},
+    {"from_id": "ap_awesome_memory", "to_id": "ap_memory_survey", "relation": "EXTENDS", "weight": 0.8, "properties": {}},
+    {"from_id": "ap_agentic_reasoning", "to_id": "ap_planning_survey", "relation": "EXTENDS", "weight": 0.7, "properties": {}},
+    {"from_id": "ap_autonomous_agents", "to_id": "convergence_trugs_agent", "relation": "CONTEXTUALIZES", "weight": 0.6, "properties": {"connection": "Reviews 2023-2025 agent frameworks — TRUGS-AGENT is the 2026 answer"}}
+  ]
+}

--- a/installers/pip/src/trugs_agent/templates/tools/__init__.py
+++ b/installers/pip/src/trugs_agent/templates/tools/__init__.py
@@ -1,0 +1,1 @@
+"""TRUGS CLI tools — create, read, update, delete operations on TRUG graphs."""

--- a/installers/pip/src/trugs_agent/templates/tools/test_validate.py
+++ b/installers/pip/src/trugs_agent/templates/tools/test_validate.py
@@ -1,0 +1,541 @@
+"""Tests for TRUGS validator — all 16 CORE rules."""
+
+import json
+import tempfile
+from pathlib import Path
+from copy import deepcopy
+
+from validate import (
+    validate, validate_file, ValidationResult,
+    rule_1_unique_ids, rule_2_edge_id_validity, rule_3_hierarchy_consistency,
+    rule_4_metric_level_ordering, rule_5_dimension_declaration,
+    rule_6_required_fields, rule_7_field_type_correctness,
+    rule_8_extension_declaration, rule_9_metric_level_format,
+    rule_10_subject_operation, rule_11_operation_object,
+    rule_12_modifier_entity, rule_13_qualifier_operation,
+    rule_14_constraint_subject, rule_15_no_double_negation,
+    rule_16_reference_scope,
+)
+
+
+# ─── Fixtures ──────────────────────────────────────────────────────────────────
+
+MINIMAL_VALID = {
+    "name": "Test",
+    "version": "1.0.0",
+    "type": "CODE",
+    "dimensions": {"d": {"description": "test", "base_level": "BASE"}},
+    "capabilities": {"extensions": [], "vocabularies": [], "profiles": []},
+    "nodes": [
+        {
+            "id": "root",
+            "type": "MODULE",
+            "properties": {},
+            "parent_id": None,
+            "contains": [],
+            "metric_level": "DEKA_MODULE",
+            "dimension": "d",
+        }
+    ],
+    "edges": [],
+}
+
+MINIMAL_V091 = {
+    "name": "Test v1.0.0",
+    "version": "1.0.0",
+    "type": "CODE",
+    "dimensions": {"d": {"description": "test"}},
+    "capabilities": {"extensions": [], "vocabularies": ["core_v1.0.0"], "profiles": []},
+    "nodes": [
+        {
+            "id": "system",
+            "type": "PARTY",
+            "properties": {},
+            "parent_id": None,
+            "contains": [],
+            "metric_level": "BASE_ACTOR",
+            "dimension": "d",
+        }
+    ],
+    "edges": [],
+}
+
+
+def _make(**overrides):
+    t = deepcopy(MINIMAL_VALID)
+    t.update(overrides)
+    return t
+
+
+def _make_v091(**overrides):
+    t = deepcopy(MINIMAL_V091)
+    t.update(overrides)
+    return t
+
+
+def _run(trug):
+    return validate(trug)
+
+
+def _errors(result):
+    return [e.code for e in result.errors]
+
+
+# ─── Rule 1: Unique IDs ───────────────────────────────────────────────────────
+
+def test_rule_1_pass():
+    r = _run(MINIMAL_VALID)
+    assert "DUPLICATE_NODE_ID" not in _errors(r)
+
+
+def test_rule_1_duplicate():
+    t = _make(nodes=[
+        {"id": "a", "type": "X", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_X", "dimension": "d"},
+        {"id": "a", "type": "Y", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_Y", "dimension": "d"},
+    ])
+    r = _run(t)
+    assert "DUPLICATE_NODE_ID" in _errors(r)
+
+
+def test_rule_1_missing_id():
+    t = _make(nodes=[
+        {"type": "X", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_X", "dimension": "d"},
+    ])
+    r = _run(t)
+    assert "MISSING_NODE_ID" in _errors(r)
+
+
+# ─── Rule 2: Edge ID Validity ─────────────────────────────────────────────────
+
+def test_rule_2_pass():
+    t = _make(
+        nodes=[
+            {"id": "a", "type": "X", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_X", "dimension": "d"},
+            {"id": "b", "type": "Y", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_Y", "dimension": "d"},
+        ],
+        edges=[{"from_id": "a", "to_id": "b", "relation": "CALLS"}],
+    )
+    r = _run(t)
+    assert "INVALID_EDGE_REFERENCE" not in _errors(r)
+
+
+def test_rule_2_invalid_from():
+    t = _make(edges=[{"from_id": "ghost", "to_id": "root", "relation": "X"}])
+    r = _run(t)
+    assert "INVALID_EDGE_REFERENCE" in _errors(r)
+
+
+def test_rule_2_cross_folder_ref_allowed():
+    t = _make(edges=[{"from_id": "root", "to_id": "other_folder:node_1", "relation": "X"}])
+    r = _run(t)
+    assert "INVALID_EDGE_REFERENCE" not in _errors(r)
+
+
+# ─── Rule 3: Hierarchy Consistency ─────────────────────────────────────────────
+
+def test_rule_3_pass():
+    t = _make(nodes=[
+        {"id": "parent", "type": "X", "properties": {}, "parent_id": None, "contains": ["child"], "metric_level": "DEKA_X", "dimension": "d"},
+        {"id": "child", "type": "Y", "properties": {}, "parent_id": "parent", "contains": [], "metric_level": "BASE_Y", "dimension": "d"},
+    ])
+    r = _run(t)
+    assert "INCONSISTENT_HIERARCHY" not in _errors(r)
+
+
+def test_rule_3_parent_missing_child():
+    t = _make(nodes=[
+        {"id": "parent", "type": "X", "properties": {}, "parent_id": None, "contains": [], "metric_level": "DEKA_X", "dimension": "d"},
+        {"id": "child", "type": "Y", "properties": {}, "parent_id": "parent", "contains": [], "metric_level": "BASE_Y", "dimension": "d"},
+    ])
+    r = _run(t)
+    assert "INCONSISTENT_HIERARCHY" in _errors(r)
+
+
+def test_rule_3_contains_missing_parent():
+    t = _make(nodes=[
+        {"id": "parent", "type": "X", "properties": {}, "parent_id": None, "contains": ["child"], "metric_level": "DEKA_X", "dimension": "d"},
+        {"id": "child", "type": "Y", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_Y", "dimension": "d"},
+    ])
+    r = _run(t)
+    assert "INCONSISTENT_HIERARCHY" in _errors(r)
+
+
+# ─── Rule 4: Metric Level Ordering ────────────────────────────────────────────
+
+def test_rule_4_pass():
+    t = _make(nodes=[
+        {"id": "p", "type": "X", "properties": {}, "parent_id": None, "contains": ["c"], "metric_level": "DEKA_X", "dimension": "d"},
+        {"id": "c", "type": "Y", "properties": {}, "parent_id": "p", "contains": [], "metric_level": "BASE_Y", "dimension": "d"},
+    ])
+    r = _run(t)
+    assert "INVALID_METRIC_ORDERING" not in _errors(r)
+
+
+def test_rule_4_child_bigger_than_parent():
+    t = _make(nodes=[
+        {"id": "p", "type": "X", "properties": {}, "parent_id": None, "contains": ["c"], "metric_level": "BASE_X", "dimension": "d"},
+        {"id": "c", "type": "Y", "properties": {}, "parent_id": "p", "contains": [], "metric_level": "KILO_Y", "dimension": "d"},
+    ])
+    r = _run(t)
+    assert "INVALID_METRIC_ORDERING" in _errors(r)
+
+
+# ─── Rule 5: Dimension Declaration ────────────────────────────────────────────
+
+def test_rule_5_pass():
+    r = _run(MINIMAL_VALID)
+    assert "UNDECLARED_DIMENSION" not in _errors(r)
+
+
+def test_rule_5_undeclared():
+    t = _make(nodes=[
+        {"id": "x", "type": "X", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_X", "dimension": "nonexistent"},
+    ])
+    r = _run(t)
+    assert "UNDECLARED_DIMENSION" in _errors(r)
+
+
+# ─── Rule 6: Required Fields ──────────────────────────────────────────────────
+
+def test_rule_6_pass():
+    r = _run(MINIMAL_VALID)
+    assert "MISSING_REQUIRED_FIELD" not in _errors(r)
+
+
+def test_rule_6_missing_root_field():
+    t = {"version": "1.0.0", "type": "X", "nodes": [], "edges": []}  # missing 'name'
+    r = _run(t)
+    assert "MISSING_REQUIRED_FIELD" in _errors(r)
+
+
+def test_rule_6_missing_node_field():
+    t = _make(nodes=[{"id": "x", "type": "X"}])  # missing properties, parent_id, contains, metric_level
+    r = _run(t)
+    codes = _errors(r)
+    assert codes.count("MISSING_REQUIRED_FIELD") >= 3
+
+
+# ─── Rule 7: Field Type Correctness ───────────────────────────────────────────
+
+def test_rule_7_pass():
+    r = _run(MINIMAL_VALID)
+    assert "INVALID_FIELD_TYPE" not in _errors(r)
+
+
+def test_rule_7_id_not_string():
+    t = _make(nodes=[
+        {"id": 123, "type": "X", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_X", "dimension": "d"},
+    ])
+    r = _run(t)
+    assert "INVALID_FIELD_TYPE" in _errors(r)
+
+
+def test_rule_7_weight_out_of_range():
+    t = _make(edges=[{"from_id": "root", "to_id": "root", "relation": "X", "weight": 1.5}])
+    r = _run(t)
+    assert "INVALID_EDGE_WEIGHT" in _errors(r)
+
+
+def test_rule_7_weight_boolean():
+    t = _make(edges=[{"from_id": "root", "to_id": "root", "relation": "X", "weight": True}])
+    r = _run(t)
+    assert "INVALID_EDGE_WEIGHT" in _errors(r)
+
+
+# ─── Rule 8: Extension Declaration ────────────────────────────────────────────
+
+def test_rule_8_pass():
+    r = _run(MINIMAL_VALID)
+    assert "UNDECLARED_EXTENSION" not in _errors(r)
+
+
+def test_rule_8_undeclared_typed():
+    t = _make(nodes=[
+        {"id": "x", "type": "X", "properties": {"type_info": {"category": "func"}}, "parent_id": None, "contains": [], "metric_level": "BASE_X", "dimension": "d"},
+    ])
+    r = _run(t)
+    assert "UNDECLARED_EXTENSION" in _errors(r)
+
+
+# ─── Rule 9: Metric Level Format ──────────────────────────────────────────────
+
+def test_rule_9_pass():
+    r = _run(MINIMAL_VALID)
+    assert "INVALID_METRIC_FORMAT" not in _errors(r)
+
+
+def test_rule_9_no_underscore():
+    t = _make(nodes=[
+        {"id": "x", "type": "X", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASEMODULE", "dimension": "d"},
+    ])
+    r = _run(t)
+    assert "INVALID_METRIC_FORMAT" in _errors(r)
+
+
+def test_rule_9_invalid_prefix():
+    t = _make(nodes=[
+        {"id": "x", "type": "X", "properties": {}, "parent_id": None, "contains": [], "metric_level": "ULTRA_MODULE", "dimension": "d"},
+    ])
+    r = _run(t)
+    assert "INVALID_METRIC_FORMAT" in _errors(r)
+
+
+# ─── Rule 10: Subject-Operation Compatibility ─────────────────────────────────
+
+def test_rule_10_actor_can_do_anything():
+    t = _make_v091(
+        nodes=[
+            {"id": "p", "type": "PARTY", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_ACTOR", "dimension": "d"},
+            {"id": "d", "type": "DATA", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_DATA", "dimension": "d"},
+        ],
+        edges=[{"from_id": "p", "to_id": "d", "relation": "FILTER"}],
+    )
+    r = _run(t)
+    assert "INCOMPATIBLE_SUBJECT_OPERATION" not in _errors(r)
+
+
+def test_rule_10_artifact_cannot_transform():
+    t = _make_v091(
+        nodes=[
+            {"id": "d", "type": "DATA", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_DATA", "dimension": "d"},
+            {"id": "d2", "type": "RECORD", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_RECORD", "dimension": "d"},
+        ],
+        edges=[{"from_id": "d", "to_id": "d2", "relation": "FILTER"}],
+    )
+    r = _run(t)
+    assert "INCOMPATIBLE_SUBJECT_OPERATION" in _errors(r)
+
+
+def test_rule_10_artifact_can_exists():
+    t = _make_v091(
+        nodes=[
+            {"id": "d", "type": "DATA", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_DATA", "dimension": "d"},
+        ],
+        edges=[{"from_id": "d", "to_id": "d", "relation": "EXISTS"}],
+    )
+    r = _run(t)
+    assert "INCOMPATIBLE_SUBJECT_OPERATION" not in _errors(r)
+
+
+def test_rule_10_container_can_transform():
+    t = _make_v091(
+        nodes=[
+            {"id": "pipe", "type": "PIPELINE", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_PIPE", "dimension": "d"},
+            {"id": "d", "type": "DATA", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_DATA", "dimension": "d"},
+        ],
+        edges=[{"from_id": "pipe", "to_id": "d", "relation": "FILTER"}],
+    )
+    r = _run(t)
+    assert "INCOMPATIBLE_SUBJECT_OPERATION" not in _errors(r)
+
+
+def test_rule_10_not_triggered_without_v091():
+    """Rules 10-16 only fire with core_v1.0.0 capability."""
+    t = _make(
+        nodes=[
+            {"id": "d", "type": "DATA", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_DATA", "dimension": "d"},
+        ],
+        edges=[{"from_id": "d", "to_id": "d", "relation": "FILTER"}],
+    )
+    r = _run(t)
+    assert "INCOMPATIBLE_SUBJECT_OPERATION" not in _errors(r)
+
+
+# ─── Rule 11: Operation-Object Compatibility ──────────────────────────────────
+
+def test_rule_11_transform_on_artifact():
+    t = _make_v091(
+        nodes=[
+            {"id": "p", "type": "PARTY", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_ACTOR", "dimension": "d"},
+            {"id": "d", "type": "DATA", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_DATA", "dimension": "d"},
+        ],
+        edges=[{"from_id": "p", "to_id": "d", "relation": "FILTER"}],
+    )
+    r = _run(t)
+    assert "INCOMPATIBLE_OPERATION_OBJECT" not in _errors(r)
+
+
+def test_rule_11_transform_on_actor_fails():
+    t = _make_v091(
+        nodes=[
+            {"id": "p1", "type": "PARTY", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_ACTOR", "dimension": "d"},
+            {"id": "p2", "type": "AGENT", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_AGENT", "dimension": "d"},
+        ],
+        edges=[{"from_id": "p1", "to_id": "p2", "relation": "FILTER"}],
+    )
+    r = _run(t)
+    assert "INCOMPATIBLE_OPERATION_OBJECT" in _errors(r)
+
+
+def test_rule_11_permit_on_actor():
+    t = _make_v091(
+        nodes=[
+            {"id": "p1", "type": "PARTY", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_ACTOR", "dimension": "d"},
+            {"id": "p2", "type": "AGENT", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_AGENT", "dimension": "d"},
+        ],
+        edges=[{"from_id": "p1", "to_id": "p2", "relation": "GRANT"}],
+    )
+    r = _run(t)
+    assert "INCOMPATIBLE_OPERATION_OBJECT" not in _errors(r)
+
+
+def test_rule_11_resolve_on_outcome():
+    t = _make_v091(
+        nodes=[
+            {"id": "p", "type": "PARTY", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_ACTOR", "dimension": "d"},
+            {"id": "e", "type": "ERROR", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_ERR", "dimension": "d"},
+        ],
+        edges=[{"from_id": "p", "to_id": "e", "relation": "HANDLE"}],
+    )
+    r = _run(t)
+    assert "INCOMPATIBLE_OPERATION_OBJECT" not in _errors(r)
+
+
+# ─── Rule 14: Constraint-Subject ───────────────────────────────────────────────
+
+def test_rule_14_modal_on_actor():
+    t = _make_v091(
+        edges=[{"from_id": "system", "to_id": "system", "relation": "SHALL"}],
+    )
+    r = _run(t)
+    assert "CONSTRAINT_REQUIRES_ACTOR" not in _errors(r)
+
+
+def test_rule_14_modal_on_non_actor():
+    t = _make_v091(
+        nodes=[
+            {"id": "d", "type": "DATA", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_DATA", "dimension": "d"},
+        ],
+        edges=[{"from_id": "d", "to_id": "d", "relation": "SHALL"}],
+    )
+    r = _run(t)
+    assert "CONSTRAINT_REQUIRES_ACTOR" in _errors(r)
+
+
+# ─── Rule 15: No Double Negation ──────────────────────────────────────────────
+
+def test_rule_15_no_double_neg():
+    t = _make_v091(
+        nodes=[
+            {"id": "p", "type": "PARTY", "properties": {"scope": {"quantifier": "NO"}}, "parent_id": None, "contains": [], "metric_level": "BASE_ACTOR", "dimension": "d"},
+        ],
+        edges=[{"from_id": "p", "to_id": "p", "relation": "SHALL_NOT"}],
+    )
+    r = _run(t)
+    assert "DOUBLE_NEGATION" in _errors(r)
+
+
+def test_rule_15_single_neg_ok():
+    t = _make_v091(
+        nodes=[
+            {"id": "p", "type": "PARTY", "properties": {"scope": {"quantifier": "ALL"}}, "parent_id": None, "contains": [], "metric_level": "BASE_ACTOR", "dimension": "d"},
+        ],
+        edges=[{"from_id": "p", "to_id": "p", "relation": "SHALL_NOT"}],
+    )
+    r = _run(t)
+    assert "DOUBLE_NEGATION" not in _errors(r)
+
+
+# ─── Rule 16: Reference Scope ─────────────────────────────────────────────────
+
+def test_rule_16_resolved_reference():
+    t = _make_v091(
+        nodes=[
+            {"id": "p", "type": "PARTY", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_ACTOR", "dimension": "d"},
+            {"id": "SELF", "type": "DATA", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_REF", "dimension": "d"},
+        ],
+        edges=[{"from_id": "p", "to_id": "SELF", "relation": "REFERENCES"}],
+    )
+    r = _run(t)
+    assert "UNRESOLVED_REFERENCE" not in _errors(r)
+
+
+def test_rule_16_unresolved_reference():
+    t = _make_v091(
+        edges=[{"from_id": "system", "to_id": "RESULT", "relation": "REFERENCES"}],
+    )
+    r = _run(t)
+    assert "UNRESOLVED_REFERENCE" in _errors(r)
+
+
+# ─── Integration: validate_file ────────────────────────────────────────────────
+
+def test_validate_file_valid():
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".trug.json", delete=False) as f:
+        json.dump(MINIMAL_VALID, f)
+        f.flush()
+        r = validate_file(Path(f.name))
+    assert r.valid
+
+
+def test_validate_file_invalid_json():
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        f.write("{bad json")
+        f.flush()
+        r = validate_file(Path(f.name))
+    assert not r.valid
+    assert "PARSE_ERROR" in _errors(r)
+
+
+def test_validate_file_not_found():
+    r = validate_file(Path("/nonexistent/path.json"))
+    assert not r.valid
+    assert "FILE_NOT_FOUND" in _errors(r)
+
+
+# ─── Integration: Full validate ────────────────────────────────────────────────
+
+def test_minimal_valid_passes():
+    r = validate(MINIMAL_VALID)
+    assert r.valid
+
+
+def test_minimal_v091_passes():
+    r = validate(MINIMAL_V091)
+    assert r.valid
+
+
+def test_not_a_dict():
+    r = validate([1, 2, 3])
+    assert not r.valid
+    assert "INVALID_ROOT" in _errors(r)
+
+
+def test_v091_opt_in():
+    """core_v1.0.0 rules only fire when declared."""
+    # This TRUG has DATA doing FILTER (invalid under rule 10) but no core_v1.0.0
+    t = _make(
+        nodes=[
+            {"id": "d", "type": "DATA", "properties": {}, "parent_id": None, "contains": [], "metric_level": "BASE_DATA", "dimension": "d"},
+        ],
+        edges=[{"from_id": "d", "to_id": "d", "relation": "FILTER"}],
+    )
+    r = validate(t)
+    assert r.valid  # No compositional rules fired
+
+    # Same TRUG with core_v1.0.0 — should fail
+    t["capabilities"]["vocabularies"] = ["core_v1.0.0"]
+    r = validate(t)
+    assert not r.valid
+
+
+# ─── Run ───────────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    import sys
+    tests = [(name, obj) for name, obj in globals().items() if name.startswith("test_") and callable(obj)]
+    passed = 0
+    failed = 0
+    for name, fn in sorted(tests):
+        try:
+            fn()
+            passed += 1
+            print(f"  PASS  {name}")
+        except AssertionError as e:
+            failed += 1
+            print(f"  FAIL  {name}: {e}")
+        except Exception as e:
+            failed += 1
+            print(f"  ERROR {name}: {type(e).__name__}: {e}")
+    print(f"\n{passed + failed} tests: {passed} passed, {failed} failed")
+    sys.exit(1 if failed else 0)

--- a/installers/pip/src/trugs_agent/templates/tools/validate.py
+++ b/installers/pip/src/trugs_agent/templates/tools/validate.py
@@ -1,0 +1,526 @@
+"""TRUGS validator — enforces all 16 CORE rules.
+
+Rules 1-9: Structural (always enforced)
+Rules 10-16: Compositional (enforced when core_v1.0.0 declared)
+
+Usage:
+    python -m trugs_llc.tools.validate <file.trug.json>
+    python -m trugs_llc.tools.validate --all <directory>
+"""
+
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+
+# ─── Primitives ────────────────────────────────────────────────────────────────
+# From TRUGS_LLC/TRUGS_LANGUAGE/SPEC_vocabulary.md
+
+ENTITY_ACTORS = {"TRANSFORM", "PARTY", "AGENT", "PRINCIPAL", "PROCESS", "SERVICE", "FUNCTION"}
+ENTITY_ARTIFACTS = {"DATA", "FILE", "RECORD", "MESSAGE", "STREAM", "RESOURCE", "INSTRUMENT"}
+ENTITY_CONTAINERS = {"PIPELINE", "STAGE", "MODULE", "NAMESPACE"}
+ENTITY_BOUNDARIES = {"ENTRY", "FLOW_ENTRY", "EXIT", "FLOW_EXIT", "INTERFACE", "ENDPOINT", "JURISDICTION", "DEADLINE"}
+ENTITY_OUTCOMES = {"RESULT", "ERROR", "EXCEPTION", "REMEDY"}
+
+ALL_ENTITIES = ENTITY_ACTORS | ENTITY_ARTIFACTS | ENTITY_CONTAINERS | ENTITY_BOUNDARIES | ENTITY_OUTCOMES
+
+OP_TRANSFORM = {"FILTER", "EXCLUDE", "MAP", "SORT", "MERGE", "SPLIT", "FLATTEN", "AGGREGATE", "GROUP", "RENAME", "BATCH", "DISTINCT", "TAKE", "SKIP"}
+OP_MOVE = {"READ", "WRITE", "SEND", "RECEIVE", "RETURN", "REQUEST", "RESPOND", "AUTHENTICATE", "DELIVER", "ASSIGN"}
+OP_OBLIGATE = {"VALIDATE", "ASSERT", "REQUIRE", "SHALL"}
+OP_PERMIT = {"ALLOW", "APPROVE", "GRANT", "OVERRIDE", "MAY"}
+OP_PROHIBIT = {"DENY", "REJECT", "SHALL_NOT", "REVOKE"}
+OP_CONTROL = {"BRANCH", "MATCH", "RETRY", "TIMEOUT", "THROW", "EXISTS", "EXPIRE", "EQUALS", "EXCEEDS", "PRECEDES"}
+OP_CONTROL_COMPARISON = {"EXISTS", "EQUALS", "EXCEEDS", "PRECEDES", "EXPIRE"}
+OP_BIND = {"DEFINE", "DECLARE", "IMPLEMENT", "NEST", "AUGMENT", "REPLACE", "CITE", "ADMINISTER", "STIPULATE"}
+OP_RESOLVE = {"CATCH", "HANDLE", "RECOVER", "CURE", "INDEMNIFY"}
+
+ALL_OPERATIONS = OP_TRANSFORM | OP_MOVE | OP_OBLIGATE | OP_PERMIT | OP_PROHIBIT | OP_CONTROL | OP_BIND | OP_RESOLVE
+
+MODALS = {"SHALL", "SHALL_NOT", "MAY"}
+
+MOD_TYPE = {"STRING", "INTEGER", "BOOLEAN", "ARRAY", "OBJECT"}
+MOD_ACCESS = {"PUBLIC", "PRIVATE", "PROTECTED", "READONLY", "CONFIDENTIAL"}
+MOD_STATE = {"VALID", "INVALID", "NULL", "EMPTY", "PENDING", "ACTIVE", "FAILED", "MUTABLE", "IMMUTABLE", "BINDING", "VOID", "ENFORCEABLE", "EXPIRED", "PRECEDENT"}
+MOD_QUANTITY = {"REQUIRED", "OPTIONAL", "UNIQUE", "MULTIPLE", "SOLE", "JOINT"}
+MOD_PRIORITY = {"DEFAULT", "CRITICAL", "HIGH", "LOW", "MATERIAL", "SUBORDINATE"}
+
+QUAL_TIMING = {"ASYNC", "SYNC", "SEQUENTIAL", "PARALLEL", "IMMEDIATE", "LAZY", "PROMPTLY", "FORTHWITH", "WITHIN"}
+QUAL_REPETITION = {"ONCE", "ALWAYS", "NEVER", "BOUNDED"}
+QUAL_DEGREE = {"STRICTLY", "PARTIALLY", "SUBSTANTIALLY", "REASONABLY"}
+QUAL_CONDITION = {"UNCONDITIONALLY", "CONDITIONALLY"}
+
+SELECTOR_NEGATIVE = {"NO", "NONE"}
+
+SI_PREFIXES = {
+    "YOTTA", "ZETTA", "EXA", "PETA", "TERA", "GIGA", "MEGA",
+    "KILO", "HECTO", "DEKA", "BASE", "DECI", "CENTI", "MILLI",
+    "MICRO", "NANO", "PICO", "FEMTO", "ATTO", "ZEPTO", "YOCTO"
+}
+
+SI_VALUES = {
+    "YOTTA": 1e24, "ZETTA": 1e21, "EXA": 1e18, "PETA": 1e15,
+    "TERA": 1e12, "GIGA": 1e9, "MEGA": 1e6, "KILO": 1e3,
+    "HECTO": 1e2, "DEKA": 1e1, "BASE": 1e0, "DECI": 1e-1,
+    "CENTI": 1e-2, "MILLI": 1e-3, "MICRO": 1e-6, "NANO": 1e-9,
+    "PICO": 1e-12, "FEMTO": 1e-15, "ATTO": 1e-18,
+    "ZEPTO": 1e-21, "YOCTO": 1e-24
+}
+
+
+# ─── Result Types ──────────────────────────────────────────────────────────────
+
+@dataclass
+class ValidationError:
+    code: str
+    message: str
+    location: str = ""
+    node_id: Optional[str] = None
+
+
+@dataclass
+class ValidationResult:
+    errors: List[ValidationError] = field(default_factory=list)
+    warnings: List[ValidationError] = field(default_factory=list)
+
+    @property
+    def valid(self) -> bool:
+        return len(self.errors) == 0
+
+    def error(self, code: str, message: str, location: str = "", node_id: Optional[str] = None):
+        self.errors.append(ValidationError(code, message, location, node_id))
+
+    def warn(self, code: str, message: str, location: str = "", node_id: Optional[str] = None):
+        self.warnings.append(ValidationError(code, message, location, node_id))
+
+    def summary(self) -> str:
+        if self.valid and not self.warnings:
+            return "VALID"
+        parts = []
+        if self.errors:
+            parts.append(f"{len(self.errors)} errors")
+        if self.warnings:
+            parts.append(f"{len(self.warnings)} warnings")
+        return ", ".join(parts)
+
+
+# ─── Helpers ───────────────────────────────────────────────────────────────────
+
+def _entity_class(node_type: str) -> Optional[str]:
+    if node_type in ENTITY_ACTORS:
+        return "Actor"
+    if node_type in ENTITY_ARTIFACTS:
+        return "Artifact"
+    if node_type in ENTITY_CONTAINERS:
+        return "Container"
+    if node_type in ENTITY_BOUNDARIES:
+        return "Boundary"
+    if node_type in ENTITY_OUTCOMES:
+        return "Outcome"
+    return None
+
+
+def _op_class(operation: str) -> Optional[str]:
+    if operation in OP_TRANSFORM:
+        return "Transform"
+    if operation in OP_MOVE:
+        return "Move"
+    if operation in OP_OBLIGATE:
+        return "Obligate"
+    if operation in OP_PERMIT:
+        return "Permit"
+    if operation in OP_PROHIBIT:
+        return "Prohibit"
+    if operation in OP_CONTROL:
+        return "Control"
+    if operation in OP_BIND:
+        return "Bind"
+    if operation in OP_RESOLVE:
+        return "Resolve"
+    return None
+
+
+def _has_core_v091(trug: Dict[str, Any]) -> bool:
+    caps = trug.get("capabilities", {})
+    vocabs = caps.get("vocabularies", [])
+    return "core_v1.0.0" in vocabs
+
+
+# ─── Rules 1-9: Structural ────────────────────────────────────────────────────
+
+def rule_1_unique_ids(trug: Dict[str, Any], r: ValidationResult):
+    seen: Set[str] = set()
+    for i, node in enumerate(trug.get("nodes", [])):
+        nid = node.get("id")
+        if not nid:
+            r.error("MISSING_NODE_ID", f"nodes[{i}] missing 'id'", f"nodes[{i}]")
+        elif nid in seen:
+            r.error("DUPLICATE_NODE_ID", f"Duplicate node ID '{nid}'", f"nodes[{i}]", nid)
+        else:
+            seen.add(nid)
+
+
+def rule_2_edge_id_validity(trug: Dict[str, Any], r: ValidationResult):
+    node_ids = {n.get("id") for n in trug.get("nodes", []) if n.get("id")}
+    for i, edge in enumerate(trug.get("edges", [])):
+        fid = edge.get("from_id")
+        tid = edge.get("to_id")
+        if fid and fid not in node_ids:
+            r.error("INVALID_EDGE_REFERENCE", f"Edge from_id '{fid}' not found", f"edges[{i}]")
+        if tid and ":" not in str(tid) and tid not in node_ids:
+            r.error("INVALID_EDGE_REFERENCE", f"Edge to_id '{tid}' not found", f"edges[{i}]")
+
+
+def rule_3_hierarchy_consistency(trug: Dict[str, Any], r: ValidationResult):
+    node_map = {n.get("id"): n for n in trug.get("nodes", []) if n.get("id")}
+    for nid, node in node_map.items():
+        pid = node.get("parent_id")
+        if pid and pid in node_map:
+            parent = node_map[pid]
+            if nid not in parent.get("contains", []):
+                r.error("INCONSISTENT_HIERARCHY", f"'{nid}' has parent_id='{pid}' but parent's contains[] missing it", node_id=nid)
+        for cid in node.get("contains", []):
+            if cid in node_map:
+                child = node_map[cid]
+                if child.get("parent_id") != nid:
+                    r.error("INCONSISTENT_HIERARCHY", f"'{nid}' lists '{cid}' in contains[] but child's parent_id='{child.get('parent_id')}'", node_id=nid)
+
+
+def rule_4_metric_level_ordering(trug: Dict[str, Any], r: ValidationResult):
+    node_map = {n.get("id"): n for n in trug.get("nodes", []) if n.get("id")}
+    for nid, node in node_map.items():
+        pid = node.get("parent_id")
+        if not pid or pid not in node_map:
+            continue
+        parent = node_map[pid]
+        p_ml = parent.get("metric_level", "")
+        c_ml = node.get("metric_level", "")
+        p_prefix = p_ml.split("_")[0] if "_" in p_ml else ""
+        c_prefix = c_ml.split("_")[0] if "_" in c_ml else ""
+        if p_prefix in SI_VALUES and c_prefix in SI_VALUES:
+            if SI_VALUES[p_prefix] < SI_VALUES[c_prefix]:
+                r.error("INVALID_METRIC_ORDERING", f"Parent '{pid}' ({p_ml}) < child '{nid}' ({c_ml})", node_id=nid)
+
+
+def rule_5_dimension_declaration(trug: Dict[str, Any], r: ValidationResult):
+    dims = trug.get("dimensions", {})
+    if not isinstance(dims, dict):
+        return  # Malformed dimensions — rule_7 will catch the type error
+    declared = set(dims.keys())
+    for i, node in enumerate(trug.get("nodes", [])):
+        dim = node.get("dimension")
+        if dim and dim not in declared:
+            r.error("UNDECLARED_DIMENSION", f"Node '{node.get('id')}' uses undeclared dimension '{dim}'", node_id=node.get("id"))
+
+
+def rule_6_required_fields(trug: Dict[str, Any], r: ValidationResult):
+    # Root fields checked separately in validate() for early return
+    node_fields = ["id", "type", "properties", "parent_id", "contains", "metric_level"]
+    for i, node in enumerate(trug.get("nodes", [])):
+        for f in node_fields:
+            if f not in node:
+                r.error("MISSING_REQUIRED_FIELD", f"Node '{node.get('id', i)}' missing field '{f}'", f"nodes[{i}]", node.get("id"))
+    edge_fields = ["from_id", "to_id", "relation"]
+    for i, edge in enumerate(trug.get("edges", [])):
+        for f in edge_fields:
+            if f not in edge:
+                r.error("MISSING_REQUIRED_FIELD", f"Edge [{i}] missing field '{f}'", f"edges[{i}]")
+
+
+def rule_7_field_type_correctness(trug: Dict[str, Any], r: ValidationResult):
+    for i, node in enumerate(trug.get("nodes", [])):
+        nid = node.get("id", f"nodes[{i}]")
+        if "id" in node and not isinstance(node["id"], str):
+            r.error("INVALID_FIELD_TYPE", f"Node '{nid}': id must be string", node_id=nid)
+        if "type" in node and not isinstance(node["type"], str):
+            r.error("INVALID_FIELD_TYPE", f"Node '{nid}': type must be string", node_id=nid)
+        if "properties" in node and not isinstance(node["properties"], dict):
+            r.error("INVALID_FIELD_TYPE", f"Node '{nid}': properties must be object", node_id=nid)
+        if "parent_id" in node and node["parent_id"] is not None and not isinstance(node["parent_id"], str):
+            r.error("INVALID_FIELD_TYPE", f"Node '{nid}': parent_id must be string or null", node_id=nid)
+        if "contains" in node and not isinstance(node["contains"], list):
+            r.error("INVALID_FIELD_TYPE", f"Node '{nid}': contains must be array", node_id=nid)
+        if "metric_level" in node and not isinstance(node["metric_level"], str):
+            r.error("INVALID_FIELD_TYPE", f"Node '{nid}': metric_level must be string", node_id=nid)
+    for i, edge in enumerate(trug.get("edges", [])):
+        for f in ["from_id", "to_id", "relation"]:
+            if f in edge and not isinstance(edge[f], str):
+                r.error("INVALID_FIELD_TYPE", f"Edge [{i}]: {f} must be string", f"edges[{i}]")
+        if "weight" in edge:
+            w = edge["weight"]
+            if not isinstance(w, (int, float)) or isinstance(w, bool):
+                r.error("INVALID_EDGE_WEIGHT", f"Edge [{i}]: weight must be number 0.0-1.0", f"edges[{i}]")
+            elif w < 0.0 or w > 1.0:
+                r.error("INVALID_EDGE_WEIGHT", f"Edge [{i}]: weight {w} outside 0.0-1.0", f"edges[{i}]")
+
+
+def rule_8_extension_declaration(trug: Dict[str, Any], r: ValidationResult):
+    declared_ext = set(trug.get("capabilities", {}).get("extensions", []))
+    for i, node in enumerate(trug.get("nodes", [])):
+        props = node.get("properties", {})
+        if "type_info" in props and "typed" not in declared_ext:
+            r.error("UNDECLARED_EXTENSION", f"Node '{node.get('id')}' uses typed extension but it's not declared", node_id=node.get("id"))
+
+
+def rule_9_metric_level_format(trug: Dict[str, Any], r: ValidationResult):
+    for i, node in enumerate(trug.get("nodes", [])):
+        ml = node.get("metric_level")
+        if not ml or not isinstance(ml, str):
+            continue
+        if "_" not in ml:
+            r.error("INVALID_METRIC_FORMAT", f"metric_level '{ml}' must be PREFIX_NAME", node_id=node.get("id"))
+            continue
+        prefix = ml.split("_")[0]
+        if prefix not in SI_PREFIXES:
+            r.error("INVALID_METRIC_FORMAT", f"Invalid SI prefix '{prefix}' in '{ml}'", node_id=node.get("id"))
+
+
+# ─── Rules 10-16: Compositional (opt-in via core_v1.0.0) ──────────────────────
+
+def rule_10_subject_operation(trug: Dict[str, Any], r: ValidationResult):
+    """Subject-Operation compatibility."""
+    node_map = {n.get("id"): n for n in trug.get("nodes", []) if n.get("id")}
+    for edge in trug.get("edges", []):
+        rel = edge.get("relation", "")
+        if rel not in MODALS and rel not in ALL_OPERATIONS:
+            continue
+        fid = edge.get("from_id")
+        if fid not in node_map:
+            continue
+        subject_type = node_map[fid].get("type", "")
+        ec = _entity_class(subject_type)
+        if not ec:
+            continue
+        op = rel if rel in ALL_OPERATIONS else None
+        if not op:
+            continue
+        oc = _op_class(op)
+        if ec == "Actor":
+            continue  # Actors can do anything
+        if ec == "Container" and oc in ("Transform", "Control", "Bind"):
+            continue
+        if ec == "Artifact" and oc == "Control" and op in OP_CONTROL_COMPARISON:
+            continue
+        if ec == "Boundary" and oc == "Bind":
+            continue
+        r.error("INCOMPATIBLE_SUBJECT_OPERATION", f"'{subject_type}' ({ec}) cannot perform '{op}' ({oc})", node_id=fid)
+
+
+def rule_11_operation_object(trug: Dict[str, Any], r: ValidationResult):
+    """Operation-Object compatibility."""
+    node_map = {n.get("id"): n for n in trug.get("nodes", []) if n.get("id")}
+    for edge in trug.get("edges", []):
+        rel = edge.get("relation", "")
+        if rel not in ALL_OPERATIONS:
+            continue
+        tid = edge.get("to_id")
+        if tid not in node_map:
+            continue
+        obj_type = node_map[tid].get("type", "")
+        ec = _entity_class(obj_type)
+        if not ec:
+            continue
+        oc = _op_class(rel)
+        if ec == "Artifact" and oc in ("Transform", "Move", "Obligate", "Control", "Bind"):
+            continue
+        if ec == "Actor" and oc in ("Permit", "Prohibit"):
+            continue
+        if ec == "Container" and oc in ("Move", "Bind"):
+            continue
+        if ec == "Boundary" and oc == "Bind":
+            continue
+        if ec == "Outcome" and oc == "Resolve":
+            continue
+        r.error("INCOMPATIBLE_OPERATION_OBJECT", f"'{obj_type}' ({ec}) cannot be target of '{rel}' ({oc})", node_id=tid)
+
+
+def rule_12_modifier_entity(trug: Dict[str, Any], r: ValidationResult):
+    """Modifier-Entity compatibility."""
+    for node in trug.get("nodes", []):
+        nid = node.get("id", "?")
+        ntype = node.get("type", "")
+        ec = _entity_class(ntype)
+        if not ec:
+            continue
+        props = node.get("properties", {})
+        for key, val in props.items():
+            if not isinstance(val, str):
+                continue
+            v = val.upper()
+            if v in MOD_TYPE and ec not in ("Artifact", "Outcome"):
+                r.error("INCOMPATIBLE_MODIFIER_ENTITY", f"Type modifier '{val}' on {ec} '{nid}'", node_id=nid)
+            if v in MOD_ACCESS and ec in ("Actor", "Outcome"):
+                r.error("INCOMPATIBLE_MODIFIER_ENTITY", f"Access modifier '{val}' on {ec} '{nid}'", node_id=nid)
+            if v in MOD_QUANTITY and ec == "Boundary":
+                r.error("INCOMPATIBLE_MODIFIER_ENTITY", f"Quantity modifier '{val}' on {ec} '{nid}'", node_id=nid)
+
+
+def rule_13_qualifier_operation(trug: Dict[str, Any], r: ValidationResult):
+    """Qualifier-Operation compatibility."""
+    for node in trug.get("nodes", []):
+        ntype = node.get("type", "")
+        if ntype != "TRANSFORM":
+            continue
+        nid = node.get("id", "?")
+        props = node.get("properties", {})
+        op = props.get("operation", "")
+        oc = _op_class(op)
+        if not oc:
+            continue
+        for key, val in props.items():
+            if not isinstance(val, str):
+                continue
+            v = val.upper()
+            if v in QUAL_TIMING and oc == "Bind":
+                r.error("INCOMPATIBLE_QUALIFIER_OPERATION", f"Timing qualifier '{val}' on Bind operation '{op}' in '{nid}'", node_id=nid)
+            if v in QUAL_REPETITION and oc == "Bind":
+                r.error("INCOMPATIBLE_QUALIFIER_OPERATION", f"Repetition qualifier '{val}' on Bind operation '{op}' in '{nid}'", node_id=nid)
+            if v in QUAL_DEGREE and oc in ("Transform", "Move", "Control", "Resolve"):
+                r.error("INCOMPATIBLE_QUALIFIER_OPERATION", f"Degree qualifier '{val}' on {oc} operation '{op}' in '{nid}'", node_id=nid)
+
+
+def rule_14_constraint_subject(trug: Dict[str, Any], r: ValidationResult):
+    """Modals (SHALL, SHALL_NOT, MAY) require Actor subjects."""
+    node_map = {n.get("id"): n for n in trug.get("nodes", []) if n.get("id")}
+    for edge in trug.get("edges", []):
+        rel = edge.get("relation", "")
+        if rel not in MODALS:
+            continue
+        fid = edge.get("from_id")
+        if fid not in node_map:
+            continue
+        subject_type = node_map[fid].get("type", "")
+        if subject_type not in ENTITY_ACTORS:
+            r.error("CONSTRAINT_REQUIRES_ACTOR", f"Modal '{rel}' on non-Actor '{subject_type}' node '{fid}'", node_id=fid)
+
+
+def rule_15_no_double_negation(trug: Dict[str, Any], r: ValidationResult):
+    """Negative selector + Prohibit modal = double negation."""
+    node_map = {n.get("id"): n for n in trug.get("nodes", []) if n.get("id")}
+    for edge in trug.get("edges", []):
+        if edge.get("relation") != "SHALL_NOT":
+            continue
+        fid = edge.get("from_id")
+        if fid not in node_map:
+            continue
+        props = node_map[fid].get("properties", {})
+        scope = props.get("scope", {})
+        quantifier = scope.get("quantifier", "") if isinstance(scope, dict) else ""
+        if quantifier.upper() in SELECTOR_NEGATIVE:
+            r.error("DOUBLE_NEGATION", f"Double negation: '{quantifier}' + SHALL_NOT on '{fid}'", node_id=fid)
+
+
+def rule_16_reference_scope(trug: Dict[str, Any], r: ValidationResult):
+    """References (SELF, RESULT, etc.) must resolve within subgraph scope."""
+    references = {"SELF", "RESULT", "OUTPUT", "INPUT", "SOURCE", "TARGET", "SAID"}
+    node_ids = {n.get("id") for n in trug.get("nodes", []) if n.get("id")}
+    for edge in trug.get("edges", []):
+        if edge.get("relation") != "REFERENCES":
+            continue
+        tid = edge.get("to_id", "")
+        if tid.upper() in references and tid not in node_ids:
+            r.error("UNRESOLVED_REFERENCE", f"Reference '{tid}' does not resolve to a node", f"edge to '{tid}'")
+
+
+# ─── Main Validator ────────────────────────────────────────────────────────────
+
+def validate(trug: Dict[str, Any]) -> ValidationResult:
+    """Validate a TRUG against all applicable CORE rules."""
+    r = ValidationResult()
+
+    if not isinstance(trug, dict):
+        r.error("INVALID_ROOT", "TRUG must be a JSON object")
+        return r
+
+    # Check root structure first — can't proceed without nodes/edges
+    for root_field in ["name", "version", "type", "nodes", "edges"]:
+        if root_field not in trug:
+            r.error("MISSING_REQUIRED_FIELD", f"Missing root field '{root_field}'", "root")
+    if not r.valid:
+        return r
+
+    # Rules 1-9: always enforced
+    rule_6_required_fields(trug, r)
+
+    rule_1_unique_ids(trug, r)
+    rule_2_edge_id_validity(trug, r)
+    rule_3_hierarchy_consistency(trug, r)
+    rule_4_metric_level_ordering(trug, r)
+    rule_5_dimension_declaration(trug, r)
+    rule_7_field_type_correctness(trug, r)
+    rule_8_extension_declaration(trug, r)
+    rule_9_metric_level_format(trug, r)
+
+    # Rules 10-16: only when core_v1.0.0 declared
+    if _has_core_v091(trug):
+        rule_10_subject_operation(trug, r)
+        rule_11_operation_object(trug, r)
+        rule_12_modifier_entity(trug, r)
+        rule_13_qualifier_operation(trug, r)
+        rule_14_constraint_subject(trug, r)
+        rule_15_no_double_negation(trug, r)
+        rule_16_reference_scope(trug, r)
+
+    return r
+
+
+def validate_file(path: Path) -> ValidationResult:
+    """Load and validate a .trug.json file."""
+    r = ValidationResult()
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            trug = json.load(f)
+    except json.JSONDecodeError as e:
+        r.error("PARSE_ERROR", f"Invalid JSON: {e}", str(path))
+        return r
+    except FileNotFoundError:
+        r.error("FILE_NOT_FOUND", f"File not found: {path}", str(path))
+        return r
+    return validate(trug)
+
+
+# ─── CLI ───────────────────────────────────────────────────────────────────────
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python -m trugs_llc.tools.validate <file.trug.json> [--all <dir>]")
+        sys.exit(1)
+
+    if sys.argv[1] == "--all":
+        directory = Path(sys.argv[2]) if len(sys.argv) > 2 else Path(".")
+        files = sorted(set(directory.rglob("*.trug.json")) | set(directory.rglob("*.json")))
+        if not files:
+            print(f"No .trug.json files found in {directory}")
+            sys.exit(1)
+        total_errors = 0
+        for f in files:
+            result = validate_file(f)
+            status = "PASS" if result.valid else "FAIL"
+            print(f"  {status}  {f}  ({result.summary()})")
+            total_errors += len(result.errors)
+            for err in result.errors:
+                print(f"         {err.code}: {err.message}")
+            for warn in result.warnings:
+                print(f"         WARN {warn.code}: {warn.message}")
+        print(f"\n{len(files)} files checked, {total_errors} errors")
+        sys.exit(1 if total_errors > 0 else 0)
+    else:
+        path = Path(sys.argv[1])
+        result = validate_file(path)
+        if result.valid:
+            print(f"VALID  {path}")
+            for warn in result.warnings:
+                print(f"  WARN {warn.code}: {warn.message}")
+            sys.exit(0)
+        else:
+            print(f"INVALID  {path}")
+            for err in result.errors:
+                print(f"  ERROR {err.code}: {err.message}")
+            for warn in result.warnings:
+                print(f"  WARN {warn.code}: {warn.message}")
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/installers/sync-templates.sh
+++ b/installers/sync-templates.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Sync template files from repo root into npm and pip installer packages.
+# Run this from the repo root before publishing either package.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+COMPONENTS="AAA EPIC FOLDER MEMORY SKILLS TRUGGING WEB_HUB"
+
+for target in npm/templates pip/src/trugs_agent/templates; do
+    dest="$REPO_ROOT/installers/$target"
+    rm -rf "$dest"
+    mkdir -p "$dest"
+
+    # Copy root AGENT.md
+    cp "$REPO_ROOT/AGENT.md" "$dest/AGENT.md"
+
+    # Copy component folders (AGENT.md + README.md + examples)
+    for comp in $COMPONENTS; do
+        if [ -d "$REPO_ROOT/$comp" ]; then
+            cp -r "$REPO_ROOT/$comp" "$dest/$comp"
+        fi
+    done
+
+    # Copy validator tools
+    if [ -d "$REPO_ROOT/tools" ]; then
+        cp -r "$REPO_ROOT/tools" "$dest/tools"
+    fi
+
+    echo "Synced templates to installers/$target"
+done


### PR DESCRIPTION
## Summary

Make TRUGS-AGENT installable through every channel developers expect:

- **npm:** `npx create-trugs-agent [claude|cursor|copilot]`
- **pip:** `pip install trugs-agent && trugs-agent-init [claude|cursor|copilot]`
- **Claude Code:** `.claude-plugin/plugin.json` for plugin discovery
- **Cursor:** `.cursor/rules/trugs-agent.mdc` with `alwaysApply: true`
- **curl/git:** still works as before

All installers copy AGENT.md (renamed for target IDE), 7 component folders, and the validator into the current directory. Won't overwrite existing files. Supports all 3 IDEs via argument.

## Files

| Path | What |
|------|------|
| `.claude-plugin/plugin.json` | Claude Code plugin metadata |
| `.cursor/rules/trugs-agent.mdc` | Cursor rules — TRL primer with YAML frontmatter |
| `installers/npm/` | npm package — `npx create-trugs-agent` |
| `installers/pip/` | pip package — `trugs-agent-init` |
| `installers/sync-templates.sh` | Syncs repo content into both installer template dirs |
| `README.md` | Updated Install section with all methods |

## Test plan

- [x] `npx create-trugs-agent` → creates CLAUDE.md + 7 folders + tools/
- [x] `npx create-trugs-agent cursor` → creates .cursorrules + 7 folders + tools/
- [x] `npx create-trugs-agent copilot` → creates .github/copilot-instructions.md + 7 folders + tools/
- [x] `trugs-agent-init` (pip) → same output as npm for all 3 IDE modes
- [x] Won't overwrite existing files (safe re-run)
- [ ] Publish to npm after merge
- [ ] Publish to PyPI after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)