### PR TITLE
Add trugs as dependency, bump to v1.1.0

### DIFF
--- a/installers/pip/pyproject.toml
+++ b/installers/pip/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trugs-agent"
-version = "1.0.0"
+version = "1.1.0"
 description = "Initialize TRUGS Agent in your project — a 190-word formal instruction language for LLM coding assistants"
 readme = "README.md"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 authors = [
     { name = "TRUGS LLC" }
 ]
@@ -22,7 +22,10 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Topic :: Software Development :: Libraries",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
+dependencies = [
+    "trugs>=1.0.0",
+]
 
 [project.scripts]
 trugs-agent-init = "trugs_agent.cli:main"

--- a/installers/pip/src/trugs_agent/__init__.py
+++ b/installers/pip/src/trugs_agent/__init__.py
@@ -1,3 +1,3 @@
 """TRUGS Agent — a 190-word formal instruction language for LLM coding assistants."""
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"


### PR DESCRIPTION
## Summary

- Add `trugs>=1.0.0` as a dependency in `trugs-agent` pyproject.toml
- Bump version to 1.1.0 (already published to PyPI)
- Bump requires-python to >=3.10 to match `trugs` requirement

`pip install trugs-agent` now pulls in the full toolchain: agent files + validator + 5 CRUD tools.

## Test plan

- [x] v1.1.0 published and verified on PyPI
- [ ] `pip install trugs-agent` installs both packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)