### PR TITLE
chore(audit): fix 30 TRL relations + 6 missing folder.trug.json nodes

### DIFF
--- a/EPIC/EXAMPLE_project.trug.json
+++ b/EPIC/EXAMPLE_project.trug.json
@@ -11,7 +11,9 @@
   },
   "capabilities": {
     "extensions": [],
-    "vocabularies": ["core_v1.0.0"],
+    "vocabularies": [
+      "core_v1.0.0"
+    ],
     "profiles": []
   },
   "nodes": [
@@ -29,7 +31,9 @@
         }
       },
       "parent_id": null,
-      "contains": ["epic_example"],
+      "contains": [
+        "epic_example"
+      ],
       "metric_level": "KILO_TRACKER",
       "dimension": "project_tracking"
     },
@@ -37,7 +41,7 @@
       "id": "epic_example",
       "type": "EPIC",
       "properties": {
-        "name": "Example Epic — Replace With Your First Initiative",
+        "name": "Example Epic \u2014 Replace With Your First Initiative",
         "purpose": "What this epic achieves and why it matters.",
         "status": "IN_PROGRESS",
         "github_issue": null,
@@ -45,7 +49,10 @@
         "created_date": "2026-04-01"
       },
       "parent_id": "tracker_root",
-      "contains": ["task_example_1", "task_example_2"],
+      "contains": [
+        "task_example_1",
+        "task_example_2"
+      ],
       "metric_level": "HECTO_EPIC",
       "dimension": "project_tracking"
     },
@@ -53,7 +60,7 @@
       "id": "task_example_1",
       "type": "TASK",
       "properties": {
-        "name": "First task — replace with real work",
+        "name": "First task \u2014 replace with real work",
         "status": "TODO",
         "github_issue": null,
         "priority": "P1"
@@ -67,7 +74,7 @@
       "id": "task_example_2",
       "type": "TASK",
       "properties": {
-        "name": "Second task — depends on first",
+        "name": "Second task \u2014 depends on first",
         "status": "TODO",
         "github_issue": null,
         "priority": "P2"
@@ -80,10 +87,12 @@
   ],
   "edges": [
     {
-      "from_id": "task_example_2",
-      "to_id": "task_example_1",
-      "relation": "BLOCKS",
-      "properties": {"description": "Task 2 cannot start until task 1 is complete"}
+      "from_id": "task_example_1",
+      "to_id": "task_example_2",
+      "relation": "DEPENDS_ON",
+      "properties": {
+        "description": "Task 2 cannot start until task 1 is complete"
+      }
     }
   ]
 }

--- a/FOLDER/EXAMPLE_folder.trug.json
+++ b/FOLDER/EXAMPLE_folder.trug.json
@@ -2,7 +2,7 @@
   "name": "Auth Module",
   "version": "1.0.0",
   "type": "MODULE",
-  "description": "Authentication and authorization — JWT validation, session management, role-based access control",
+  "description": "Authentication and authorization \u2014 JWT validation, session management, role-based access control",
   "dimensions": {
     "folder_structure": {
       "description": "Auth module file and component structure",
@@ -11,7 +11,9 @@
   },
   "capabilities": {
     "extensions": [],
-    "vocabularies": ["project_v1"],
+    "vocabularies": [
+      "project_v1"
+    ],
     "profiles": []
   },
   "nodes": [
@@ -20,12 +22,19 @@
       "type": "FOLDER",
       "properties": {
         "name": "auth",
-        "purpose": "Authentication and authorization module — JWT tokens, sessions, RBAC",
+        "purpose": "Authentication and authorization module \u2014 JWT tokens, sessions, RBAC",
         "verified": false,
         "stale": false
       },
       "parent_id": null,
-      "contains": ["spec_auth", "component_jwt", "component_sessions", "component_rbac", "doc_readme", "test_suite"],
+      "contains": [
+        "spec_auth",
+        "component_jwt",
+        "component_sessions",
+        "component_rbac",
+        "doc_readme",
+        "test_suite"
+      ],
       "metric_level": "KILO_FOLDER",
       "dimension": "folder_structure"
     },
@@ -34,7 +43,7 @@
       "type": "SPECIFICATION",
       "properties": {
         "name": "SPEC_auth.md",
-        "purpose": "Formal auth specification — token format, expiration rules, role hierarchy, rate limits",
+        "purpose": "Formal auth specification \u2014 token format, expiration rules, role hierarchy, rate limits",
         "format": "markdown"
       },
       "parent_id": "auth_folder",
@@ -47,7 +56,7 @@
       "type": "COMPONENT",
       "properties": {
         "name": "jwt_handler.py",
-        "purpose": "JWT token creation, validation, and refresh — HS256, 15min access / 7d refresh",
+        "purpose": "JWT token creation, validation, and refresh \u2014 HS256, 15min access / 7d refresh",
         "language": "python"
       },
       "parent_id": "auth_folder",
@@ -60,7 +69,7 @@
       "type": "COMPONENT",
       "properties": {
         "name": "sessions.py",
-        "purpose": "Server-side session store — Redis-backed, 24h TTL, sliding expiration",
+        "purpose": "Server-side session store \u2014 Redis-backed, 24h TTL, sliding expiration",
         "language": "python"
       },
       "parent_id": "auth_folder",
@@ -73,7 +82,7 @@
       "type": "COMPONENT",
       "properties": {
         "name": "rbac.py",
-        "purpose": "Role-based access control — admin/editor/viewer hierarchy, permission checks",
+        "purpose": "Role-based access control \u2014 admin/editor/viewer hierarchy, permission checks",
         "language": "python"
       },
       "parent_id": "auth_folder",
@@ -86,7 +95,7 @@
       "type": "DOCUMENT",
       "properties": {
         "name": "README.md",
-        "purpose": "Auth module quickstart — setup, configuration, usage examples",
+        "purpose": "Auth module quickstart \u2014 setup, configuration, usage examples",
         "format": "markdown"
       },
       "parent_id": "auth_folder",
@@ -99,7 +108,7 @@
       "type": "TEST_SUITE",
       "properties": {
         "name": "tests/",
-        "purpose": "Auth test suite — 43 tests covering JWT, sessions, RBAC, and integration",
+        "purpose": "Auth test suite \u2014 43 tests covering JWT, sessions, RBAC, and integration",
         "test_count": 43
       },
       "parent_id": "auth_folder",
@@ -112,56 +121,66 @@
     {
       "from_id": "component_jwt",
       "to_id": "spec_auth",
-      "relation": "implements",
-      "properties": {"scope": "JWT token format and expiration rules"}
+      "relation": "IMPLEMENTS",
+      "properties": {
+        "scope": "JWT token format and expiration rules"
+      }
     },
     {
       "from_id": "component_sessions",
       "to_id": "spec_auth",
-      "relation": "implements",
-      "properties": {"scope": "Session TTL and sliding expiration"}
+      "relation": "IMPLEMENTS",
+      "properties": {
+        "scope": "Session TTL and sliding expiration"
+      }
     },
     {
       "from_id": "component_rbac",
       "to_id": "spec_auth",
-      "relation": "implements",
-      "properties": {"scope": "Role hierarchy and permission model"}
+      "relation": "IMPLEMENTS",
+      "properties": {
+        "scope": "Role hierarchy and permission model"
+      }
     },
     {
       "from_id": "component_rbac",
       "to_id": "component_jwt",
-      "relation": "uses",
-      "properties": {"reason": "RBAC reads role claims from JWT payload"}
+      "relation": "DEPENDS_ON",
+      "properties": {
+        "reason": "RBAC reads role claims from JWT payload"
+      }
     },
     {
       "from_id": "test_suite",
       "to_id": "component_jwt",
-      "relation": "tests",
+      "relation": "REFERENCES",
       "properties": {}
     },
     {
       "from_id": "test_suite",
       "to_id": "component_sessions",
-      "relation": "tests",
+      "relation": "REFERENCES",
       "properties": {}
     },
     {
       "from_id": "test_suite",
       "to_id": "component_rbac",
-      "relation": "tests",
+      "relation": "REFERENCES",
       "properties": {}
     },
     {
       "from_id": "doc_readme",
       "to_id": "auth_folder",
-      "relation": "describes",
+      "relation": "REFERENCES",
       "properties": {}
     },
     {
       "from_id": "component_sessions",
       "to_id": "infrastructure:redis",
-      "relation": "uses",
-      "properties": {"reason": "Redis for session storage"}
+      "relation": "DEPENDS_ON",
+      "properties": {
+        "reason": "Redis for session storage"
+      }
     }
   ]
 }

--- a/folder.trug.json
+++ b/folder.trug.json
@@ -2,16 +2,18 @@
   "name": "TRUGS-AGENT",
   "version": "1.0.0",
   "type": "PROJECT",
-  "description": "Agent system for LLMs — TRL language, 8 component modules, validator tooling, NDA example",
+  "description": "Agent system for LLMs \u2014 TRL language, 8 component modules, validator tooling, NDA example",
   "dimensions": {
     "folder_structure": {
-      "description": "Top-level repo structure — 8 component folders + tools + NDA example",
+      "description": "Top-level repo structure \u2014 8 component folders + tools + NDA example",
       "base_level": "BASE"
     }
   },
   "capabilities": {
     "extensions": [],
-    "vocabularies": ["project_v1"],
+    "vocabularies": [
+      "project_v1"
+    ],
     "profiles": []
   },
   "nodes": [
@@ -25,7 +27,26 @@
         "stale": false
       },
       "parent_id": null,
-      "contains": ["doc_agent", "doc_readme", "doc_license", "folder_aaa", "folder_epic", "folder_memory", "folder_folder", "folder_trugging", "folder_webhub", "folder_skills", "folder_nda", "folder_tools"],
+      "contains": [
+        "doc_agent",
+        "doc_readme",
+        "doc_license",
+        "folder_aaa",
+        "folder_epic",
+        "folder_memory",
+        "folder_folder",
+        "folder_trugging",
+        "folder_webhub",
+        "folder_skills",
+        "folder_nda",
+        "folder_tools",
+        "doc_contributing",
+        "doc_demo",
+        "doc_notice",
+        "folder_brochure",
+        "folder_examples",
+        "folder_installers"
+      ],
       "metric_level": "KILO_FOLDER",
       "dimension": "folder_structure"
     },
@@ -34,7 +55,7 @@
       "type": "SPECIFICATION",
       "properties": {
         "name": "AGENT.md",
-        "purpose": "Root system prompt — TRL vocabulary (190 words), grammar, parsing rules, validator reference, usage patterns",
+        "purpose": "Root system prompt \u2014 TRL vocabulary (190 words), grammar, parsing rules, validator reference, usage patterns",
         "format": "markdown",
         "lines": 305
       },
@@ -48,7 +69,7 @@
       "type": "DOCUMENT",
       "properties": {
         "name": "README.md",
-        "purpose": "Human-facing overview — install instructions, component table, adopt-one-or-all guidance",
+        "purpose": "Human-facing overview \u2014 install instructions, component table, adopt-one-or-all guidance",
         "format": "markdown",
         "lines": 66
       },
@@ -62,7 +83,7 @@
       "type": "DOCUMENT",
       "properties": {
         "name": "LICENSE",
-        "purpose": "Apache 2.0 license — TRUGS LLC",
+        "purpose": "Apache 2.0 license \u2014 TRUGS LLC",
         "format": "text"
       },
       "parent_id": "root",
@@ -75,11 +96,15 @@
       "type": "COMPONENT",
       "properties": {
         "name": "AAA",
-        "purpose": "9-phase development protocol — plan before code, audit before ship, human approves at 3 gates",
+        "purpose": "9-phase development protocol \u2014 plan before code, audit before ship, human approves at 3 gates",
         "file_count": 3
       },
       "parent_id": "root",
-      "contains": ["aaa_agent", "aaa_readme", "aaa_example"],
+      "contains": [
+        "aaa_agent",
+        "aaa_readme",
+        "aaa_example"
+      ],
       "metric_level": "DEKA_COMPONENT",
       "dimension": "folder_structure"
     },
@@ -88,7 +113,7 @@
       "type": "SPECIFICATION",
       "properties": {
         "name": "AAA/AGENT.md",
-        "purpose": "Agent instructions for AAA — all 9 phases, HITM gates, hard rules, chore vs issue paths",
+        "purpose": "Agent instructions for AAA \u2014 all 9 phases, HITM gates, hard rules, chore vs issue paths",
         "format": "markdown",
         "lines": 211
       },
@@ -102,7 +127,7 @@
       "type": "DOCUMENT",
       "properties": {
         "name": "AAA/README.md",
-        "purpose": "Human overview of AAA — two cycles, three touchpoints, when to use it",
+        "purpose": "Human overview of AAA \u2014 two cycles, three touchpoints, when to use it",
         "format": "markdown",
         "lines": 34
       },
@@ -116,7 +141,7 @@
       "type": "DOCUMENT",
       "properties": {
         "name": "AAA/EXAMPLE_email_mcp.md",
-        "purpose": "Real production AAA — email MCP server, all 9 phases with TRL specs and audit criteria",
+        "purpose": "Real production AAA \u2014 email MCP server, all 9 phases with TRL specs and audit criteria",
         "format": "markdown",
         "lines": 184
       },
@@ -130,11 +155,15 @@
       "type": "COMPONENT",
       "properties": {
         "name": "EPIC",
-        "purpose": "Portfolio tracker as a traversable TRUG graph — epics, tasks, dependency edges",
+        "purpose": "Portfolio tracker as a traversable TRUG graph \u2014 epics, tasks, dependency edges",
         "file_count": 3
       },
       "parent_id": "root",
-      "contains": ["epic_agent", "epic_readme", "epic_example"],
+      "contains": [
+        "epic_agent",
+        "epic_readme",
+        "epic_example"
+      ],
       "metric_level": "DEKA_COMPONENT",
       "dimension": "folder_structure"
     },
@@ -143,7 +172,7 @@
       "type": "SPECIFICATION",
       "properties": {
         "name": "EPIC/AGENT.md",
-        "purpose": "Agent instructions for EPIC — node types, edge relations, read/update/create lifecycle",
+        "purpose": "Agent instructions for EPIC \u2014 node types, edge relations, read/update/create lifecycle",
         "format": "markdown",
         "lines": 139
       },
@@ -157,7 +186,7 @@
       "type": "DOCUMENT",
       "properties": {
         "name": "EPIC/README.md",
-        "purpose": "Human overview of EPIC — tracker > epic > task hierarchy, when to use it",
+        "purpose": "Human overview of EPIC \u2014 tracker > epic > task hierarchy, when to use it",
         "format": "markdown",
         "lines": 33
       },
@@ -171,7 +200,7 @@
       "type": "DOCUMENT",
       "properties": {
         "name": "EPIC/EXAMPLE_project.trug.json",
-        "purpose": "Starter tracker template — 2 epics, 2 tasks, BLOCKS dependency edge",
+        "purpose": "Starter tracker template \u2014 2 epics, 2 tasks, BLOCKS dependency edge",
         "format": "json",
         "lines": 89
       },
@@ -185,11 +214,15 @@
       "type": "COMPONENT",
       "properties": {
         "name": "MEMORY",
-        "purpose": "Persistent context across sessions — 4 memory types, session lifecycle, hygiene rules",
+        "purpose": "Persistent context across sessions \u2014 4 memory types, session lifecycle, hygiene rules",
         "file_count": 3
       },
       "parent_id": "root",
-      "contains": ["memory_agent", "memory_readme", "memory_example"],
+      "contains": [
+        "memory_agent",
+        "memory_readme",
+        "memory_example"
+      ],
       "metric_level": "DEKA_COMPONENT",
       "dimension": "folder_structure"
     },
@@ -198,7 +231,7 @@
       "type": "SPECIFICATION",
       "properties": {
         "name": "MEMORY/AGENT.md",
-        "purpose": "Agent instructions for Memory — types, file format, session lifecycle, what not to save",
+        "purpose": "Agent instructions for Memory \u2014 types, file format, session lifecycle, what not to save",
         "format": "markdown",
         "lines": 179
       },
@@ -212,7 +245,7 @@
       "type": "DOCUMENT",
       "properties": {
         "name": "MEMORY/README.md",
-        "purpose": "Human overview of Memory — 4 types, save/skip rules, when to use it",
+        "purpose": "Human overview of Memory \u2014 4 types, save/skip rules, when to use it",
         "format": "markdown",
         "lines": 39
       },
@@ -226,7 +259,7 @@
       "type": "DOCUMENT",
       "properties": {
         "name": "MEMORY/EXAMPLE_MEMORY.md",
-        "purpose": "Starter memory index — 4 example entries across all memory types",
+        "purpose": "Starter memory index \u2014 4 example entries across all memory types",
         "format": "markdown",
         "lines": 14
       },
@@ -240,11 +273,15 @@
       "type": "COMPONENT",
       "properties": {
         "name": "FOLDER",
-        "purpose": "Machine-readable filesystem index — four-file pattern, node types, edge relations, CLI tools",
+        "purpose": "Machine-readable filesystem index \u2014 four-file pattern, node types, edge relations, CLI tools",
         "file_count": 3
       },
       "parent_id": "root",
-      "contains": ["folder_agent", "folder_readme", "folder_example"],
+      "contains": [
+        "folder_agent",
+        "folder_readme",
+        "folder_example"
+      ],
       "metric_level": "DEKA_COMPONENT",
       "dimension": "folder_structure"
     },
@@ -253,7 +290,7 @@
       "type": "SPECIFICATION",
       "properties": {
         "name": "FOLDER/AGENT.md",
-        "purpose": "Agent instructions for Folder — build rules, lifecycle properties, naming convention, zzz_ archive, CLI",
+        "purpose": "Agent instructions for Folder \u2014 build rules, lifecycle properties, naming convention, zzz_ archive, CLI",
         "format": "markdown",
         "lines": 311
       },
@@ -267,7 +304,7 @@
       "type": "DOCUMENT",
       "properties": {
         "name": "FOLDER/README.md",
-        "purpose": "Human overview of Folder — four-file pattern, node types, edge relations, CLI tools",
+        "purpose": "Human overview of Folder \u2014 four-file pattern, node types, edge relations, CLI tools",
         "format": "markdown",
         "lines": 74
       },
@@ -281,7 +318,7 @@
       "type": "DOCUMENT",
       "properties": {
         "name": "FOLDER/EXAMPLE_folder.trug.json",
-        "purpose": "Example folder.trug.json for an auth module — 7 nodes, 9 edges, cross-folder reference",
+        "purpose": "Example folder.trug.json for an auth module \u2014 7 nodes, 9 edges, cross-folder reference",
         "format": "json",
         "lines": 167
       },
@@ -295,11 +332,14 @@
       "type": "COMPONENT",
       "properties": {
         "name": "TRUGGING",
-        "purpose": "Methodology for describing a codebase — 4 levels from system graph to inline TRL",
+        "purpose": "Methodology for describing a codebase \u2014 4 levels from system graph to inline TRL",
         "file_count": 2
       },
       "parent_id": "root",
-      "contains": ["trugging_agent", "trugging_readme"],
+      "contains": [
+        "trugging_agent",
+        "trugging_readme"
+      ],
       "metric_level": "DEKA_COMPONENT",
       "dimension": "folder_structure"
     },
@@ -308,7 +348,7 @@
       "type": "SPECIFICATION",
       "properties": {
         "name": "TRUGGING/AGENT.md",
-        "purpose": "Agent instructions for Trugging — system/component/header/inline levels, boundary rule, step-by-step",
+        "purpose": "Agent instructions for Trugging \u2014 system/component/header/inline levels, boundary rule, step-by-step",
         "format": "markdown",
         "lines": 312
       },
@@ -322,7 +362,7 @@
       "type": "DOCUMENT",
       "properties": {
         "name": "TRUGGING/README.md",
-        "purpose": "Human overview of Trugging — 4 levels, boundary rule, agent walkthrough",
+        "purpose": "Human overview of Trugging \u2014 4 levels, boundary rule, agent walkthrough",
         "format": "markdown",
         "lines": 52
       },
@@ -336,11 +376,15 @@
       "type": "COMPONENT",
       "properties": {
         "name": "WEB_HUB",
-        "purpose": "Curated web resource graph — 3 branches (structured agent, graph native, agent protocols), 54 nodes, 51 weighted edges",
+        "purpose": "Curated web resource graph \u2014 3 branches (structured agent, graph native, agent protocols), 54 nodes, 51 weighted edges",
         "file_count": 3
       },
       "parent_id": "root",
-      "contains": ["webhub_agent", "webhub_readme", "webhub_web"],
+      "contains": [
+        "webhub_agent",
+        "webhub_readme",
+        "webhub_web"
+      ],
       "metric_level": "DEKA_COMPONENT",
       "dimension": "folder_structure"
     },
@@ -349,7 +393,7 @@
       "type": "SPECIFICATION",
       "properties": {
         "name": "WEB_HUB/AGENT.md",
-        "purpose": "Agent instructions for WEB_HUB — how to read, traverse, update, and maintain curated web resource graphs",
+        "purpose": "Agent instructions for WEB_HUB \u2014 how to read, traverse, update, and maintain curated web resource graphs",
         "format": "markdown"
       },
       "parent_id": "folder_webhub",
@@ -362,7 +406,7 @@
       "type": "DOCUMENT",
       "properties": {
         "name": "WEB_HUB/README.md",
-        "purpose": "Human overview of WEB_HUB — three branches, edge weights, how to use the research graph",
+        "purpose": "Human overview of WEB_HUB \u2014 three branches, edge weights, how to use the research graph",
         "format": "markdown"
       },
       "parent_id": "folder_webhub",
@@ -375,7 +419,7 @@
       "type": "DOCUMENT",
       "properties": {
         "name": "WEB_HUB/web.trug.json",
-        "purpose": "Three-branch web resource graph — 45 resources, 5 convergence nodes, 51 weighted edges across 10 relation types",
+        "purpose": "Three-branch web resource graph \u2014 45 resources, 5 convergence nodes, 51 weighted edges across 10 relation types",
         "format": "json"
       },
       "parent_id": "folder_webhub",
@@ -388,11 +432,14 @@
       "type": "COMPONENT",
       "properties": {
         "name": "SKILLS",
-        "purpose": "Composable agent actions — 19 primitives across 6 categories, compound composition with HITM gates",
+        "purpose": "Composable agent actions \u2014 19 primitives across 6 categories, compound composition with HITM gates",
         "file_count": 2
       },
       "parent_id": "root",
-      "contains": ["skills_agent", "skills_readme"],
+      "contains": [
+        "skills_agent",
+        "skills_readme"
+      ],
       "metric_level": "DEKA_COMPONENT",
       "dimension": "folder_structure"
     },
@@ -401,7 +448,7 @@
       "type": "SPECIFICATION",
       "properties": {
         "name": "SKILLS/AGENT.md",
-        "purpose": "Agent instructions for Skills — 19 primitive definitions in TRL, compound composition rules, 3 compound examples",
+        "purpose": "Agent instructions for Skills \u2014 19 primitive definitions in TRL, compound composition rules, 3 compound examples",
         "format": "markdown"
       },
       "parent_id": "folder_skills",
@@ -414,7 +461,7 @@
       "type": "DOCUMENT",
       "properties": {
         "name": "SKILLS/README.md",
-        "purpose": "Human overview of Skills — primitive catalog, compound composition, key rules",
+        "purpose": "Human overview of Skills \u2014 primitive catalog, compound composition, key rules",
         "format": "markdown"
       },
       "parent_id": "folder_skills",
@@ -427,12 +474,15 @@
       "type": "COMPONENT",
       "properties": {
         "name": "NDA",
-        "purpose": "Complete example — all 7 systems applied to drafting a mutual NDA under WA state law (RCW 19.108)",
+        "purpose": "Complete example \u2014 all 7 systems applied to drafting a mutual NDA under WA state law (RCW 19.108)",
         "file_count": 10,
         "role": "demonstration"
       },
       "parent_id": "root",
-      "contains": ["nda_agent", "nda_readme"],
+      "contains": [
+        "nda_agent",
+        "nda_readme"
+      ],
       "metric_level": "DEKA_COMPONENT",
       "dimension": "folder_structure"
     },
@@ -441,7 +491,7 @@
       "type": "SPECIFICATION",
       "properties": {
         "name": "NDA/AGENT.md",
-        "purpose": "Agent instructions for NDA example — 8-step walkthrough of the complete pipeline from research to indexing",
+        "purpose": "Agent instructions for NDA example \u2014 8-step walkthrough of the complete pipeline from research to indexing",
         "format": "markdown"
       },
       "parent_id": "folder_nda",
@@ -454,7 +504,7 @@
       "type": "DOCUMENT",
       "properties": {
         "name": "NDA/README.md",
-        "purpose": "Human walkthrough — how we built the NDA step by step using all 7 systems",
+        "purpose": "Human walkthrough \u2014 how we built the NDA step by step using all 7 systems",
         "format": "markdown"
       },
       "parent_id": "folder_nda",
@@ -467,11 +517,15 @@
       "type": "COMPONENT",
       "properties": {
         "name": "tools",
-        "purpose": "TRUGS validator — 16 rules (9 structural, 7 compositional), 47 tests, zero dependencies",
+        "purpose": "TRUGS validator \u2014 16 rules (9 structural, 7 compositional), 47 tests, zero dependencies",
         "file_count": 3
       },
       "parent_id": "root",
-      "contains": ["tools_validate", "tools_test", "tools_init"],
+      "contains": [
+        "tools_validate",
+        "tools_test",
+        "tools_init"
+      ],
       "metric_level": "DEKA_COMPONENT",
       "dimension": "folder_structure"
     },
@@ -480,7 +534,7 @@
       "type": "SPECIFICATION",
       "properties": {
         "name": "tools/validate.py",
-        "purpose": "TRUGS validator — 16 CORE rules enforcing graph correctness, CLI interface",
+        "purpose": "TRUGS validator \u2014 16 CORE rules enforcing graph correctness, CLI interface",
         "language": "python",
         "lines": 526
       },
@@ -494,7 +548,7 @@
       "type": "TEST_SUITE",
       "properties": {
         "name": "tools/test_validate.py",
-        "purpose": "Validator test suite — 47 tests covering all 16 rules plus integration",
+        "purpose": "Validator test suite \u2014 47 tests covering all 16 rules plus integration",
         "language": "python",
         "test_count": 47,
         "lines": 541
@@ -517,6 +571,84 @@
       "contains": [],
       "metric_level": "BASE_DOCUMENT",
       "dimension": "folder_structure"
+    },
+    {
+      "id": "doc_contributing",
+      "type": "DATA",
+      "name": "Contributing Guide",
+      "description": "Contributor onboarding and PR workflow.",
+      "parent_id": "root",
+      "contains": [],
+      "metric_level": "BASE_DOC",
+      "dimension": "documentation",
+      "properties": {
+        "path": "CONTRIBUTING.md"
+      }
+    },
+    {
+      "id": "doc_demo",
+      "type": "DATA",
+      "name": "Demo",
+      "description": "Demo walkthrough of the trugs-agent on-ramp.",
+      "parent_id": "root",
+      "contains": [],
+      "metric_level": "BASE_DOC",
+      "dimension": "documentation",
+      "properties": {
+        "path": "DEMO.md"
+      }
+    },
+    {
+      "id": "doc_notice",
+      "type": "DATA",
+      "name": "Apache 2.0 NOTICE",
+      "description": "Apache License 2.0 attribution NOTICE file.",
+      "parent_id": "root",
+      "contains": [],
+      "metric_level": "BASE_DOC",
+      "dimension": "documentation",
+      "properties": {
+        "path": "NOTICE"
+      }
+    },
+    {
+      "id": "folder_brochure",
+      "type": "DATA",
+      "name": "Marketing brochure",
+      "description": "Marketing and onboarding brochure content.",
+      "parent_id": "root",
+      "contains": [],
+      "metric_level": "DECI_FOLDER",
+      "dimension": "documentation",
+      "properties": {
+        "path": "BROCHURE/"
+      }
+    },
+    {
+      "id": "folder_examples",
+      "type": "DATA",
+      "name": "Worked examples",
+      "description": "End-to-end worked examples consuming the TRUGS-AGENT primitives.",
+      "parent_id": "root",
+      "contains": [],
+      "metric_level": "DECI_FOLDER",
+      "dimension": "examples",
+      "properties": {
+        "path": "examples/"
+      }
+    },
+    {
+      "id": "folder_installers",
+      "type": "DATA",
+      "name": "Installers (npm + pip)",
+      "description": "Distribution-channel installers that ship the templates and skills to end users.",
+      "parent_id": "root",
+      "contains": [],
+      "metric_level": "DECI_FOLDER",
+      "dimension": "distribution",
+      "properties": {
+        "path": "installers/"
+      }
     }
   ],
   "edges": [
@@ -530,145 +662,193 @@
       "from_id": "doc_agent",
       "to_id": "root",
       "relation": "GOVERNS",
-      "properties": {"scope": "TRL language foundation — all components depend on this"}
+      "properties": {
+        "scope": "TRL language foundation \u2014 all components depend on this"
+      }
     },
     {
       "from_id": "aaa_agent",
       "to_id": "doc_agent",
       "relation": "DEPENDS_ON",
-      "properties": {"reason": "AAA phases use TRL for specifications and audit criteria"}
+      "properties": {
+        "reason": "AAA phases use TRL for specifications and audit criteria"
+      }
     },
     {
       "from_id": "epic_agent",
       "to_id": "doc_agent",
       "relation": "DEPENDS_ON",
-      "properties": {"reason": "EPIC instructions written in TRL"}
+      "properties": {
+        "reason": "EPIC instructions written in TRL"
+      }
     },
     {
       "from_id": "memory_agent",
       "to_id": "doc_agent",
       "relation": "DEPENDS_ON",
-      "properties": {"reason": "Memory instructions written in TRL"}
+      "properties": {
+        "reason": "Memory instructions written in TRL"
+      }
     },
     {
       "from_id": "folder_agent",
       "to_id": "doc_agent",
       "relation": "DEPENDS_ON",
-      "properties": {"reason": "Folder instructions written in TRL"}
+      "properties": {
+        "reason": "Folder instructions written in TRL"
+      }
     },
     {
       "from_id": "trugging_agent",
       "to_id": "doc_agent",
       "relation": "DEPENDS_ON",
-      "properties": {"reason": "Trugging methodology uses both TRL and TRUG graphs"}
+      "properties": {
+        "reason": "Trugging methodology uses both TRL and TRUG graphs"
+      }
     },
     {
       "from_id": "trugging_agent",
       "to_id": "folder_agent",
       "relation": "DEPENDS_ON",
-      "properties": {"reason": "Trugging levels 1-2 produce folder.trug.json files"}
+      "properties": {
+        "reason": "Trugging levels 1-2 produce folder.trug.json files"
+      }
     },
     {
       "from_id": "aaa_example",
       "to_id": "aaa_agent",
       "relation": "REFERENCES",
-      "properties": {"scope": "Real production example of all 9 AAA phases"}
+      "properties": {
+        "scope": "Real production example of all 9 AAA phases"
+      }
     },
     {
       "from_id": "epic_example",
       "to_id": "epic_agent",
       "relation": "REFERENCES",
-      "properties": {"scope": "Starter template for EPIC tracker"}
+      "properties": {
+        "scope": "Starter template for EPIC tracker"
+      }
     },
     {
       "from_id": "memory_example",
       "to_id": "memory_agent",
       "relation": "REFERENCES",
-      "properties": {"scope": "Starter memory index with example entries"}
+      "properties": {
+        "scope": "Starter memory index with example entries"
+      }
     },
     {
       "from_id": "folder_example",
       "to_id": "folder_agent",
       "relation": "REFERENCES",
-      "properties": {"scope": "Example folder.trug.json for an auth module"}
+      "properties": {
+        "scope": "Example folder.trug.json for an auth module"
+      }
     },
     {
       "from_id": "webhub_agent",
       "to_id": "doc_agent",
       "relation": "DEPENDS_ON",
-      "properties": {"reason": "WEB_HUB instructions written in TRL"}
+      "properties": {
+        "reason": "WEB_HUB instructions written in TRL"
+      }
     },
     {
       "from_id": "nda_agent",
       "to_id": "doc_agent",
       "relation": "DEPENDS_ON",
-      "properties": {"reason": "NDA example uses TRL throughout"}
+      "properties": {
+        "reason": "NDA example uses TRL throughout"
+      }
     },
     {
       "from_id": "folder_nda",
       "to_id": "folder_aaa",
       "relation": "DEPENDS_ON",
-      "properties": {"reason": "NDA demonstrates AAA 9-phase protocol"}
+      "properties": {
+        "reason": "NDA demonstrates AAA 9-phase protocol"
+      }
     },
     {
       "from_id": "folder_nda",
       "to_id": "folder_epic",
       "relation": "DEPENDS_ON",
-      "properties": {"reason": "NDA demonstrates EPIC project tracking"}
+      "properties": {
+        "reason": "NDA demonstrates EPIC project tracking"
+      }
     },
     {
       "from_id": "folder_nda",
       "to_id": "folder_memory",
       "relation": "DEPENDS_ON",
-      "properties": {"reason": "NDA demonstrates Memory persistence"}
+      "properties": {
+        "reason": "NDA demonstrates Memory persistence"
+      }
     },
     {
       "from_id": "folder_nda",
       "to_id": "folder_folder",
       "relation": "DEPENDS_ON",
-      "properties": {"reason": "NDA demonstrates folder.trug.json indexing"}
+      "properties": {
+        "reason": "NDA demonstrates folder.trug.json indexing"
+      }
     },
     {
       "from_id": "folder_nda",
       "to_id": "folder_trugging",
       "relation": "DEPENDS_ON",
-      "properties": {"reason": "NDA demonstrates TRL in legal clauses"}
+      "properties": {
+        "reason": "NDA demonstrates TRL in legal clauses"
+      }
     },
     {
       "from_id": "folder_nda",
       "to_id": "folder_webhub",
       "relation": "DEPENDS_ON",
-      "properties": {"reason": "NDA demonstrates web resource graph for research"}
+      "properties": {
+        "reason": "NDA demonstrates web resource graph for research"
+      }
     },
     {
       "from_id": "skills_agent",
       "to_id": "doc_agent",
       "relation": "DEPENDS_ON",
-      "properties": {"reason": "Skills instructions written in TRL"}
+      "properties": {
+        "reason": "Skills instructions written in TRL"
+      }
     },
     {
       "from_id": "skills_agent",
       "to_id": "memory_agent",
       "relation": "DEPENDS_ON",
-      "properties": {"reason": "Memory primitives (memory-save, memory-read) defined here"}
+      "properties": {
+        "reason": "Memory primitives (memory-save, memory-read) defined here"
+      }
     },
     {
       "from_id": "skills_agent",
       "to_id": "epic_agent",
       "relation": "DEPENDS_ON",
-      "properties": {"reason": "EPIC primitives (epic-read, epic-sync, epic-portfolio) defined here"}
+      "properties": {
+        "reason": "EPIC primitives (epic-read, epic-sync, epic-portfolio) defined here"
+      }
     },
     {
       "from_id": "skills_agent",
       "to_id": "folder_agent",
       "relation": "DEPENDS_ON",
-      "properties": {"reason": "TRUG graph primitives (trug-sync, trug-check, trug-clean, trug-edge) defined here"}
+      "properties": {
+        "reason": "TRUG graph primitives (trug-sync, trug-check, trug-clean, trug-edge) defined here"
+      }
     },
     {
       "from_id": "webhub_web",
       "to_id": "webhub_agent",
       "relation": "REFERENCES",
-      "properties": {"scope": "Three-branch web resource graph with 54 nodes"}
+      "properties": {
+        "scope": "Three-branch web resource graph with 54 nodes"
+      }
     },
     {
       "from_id": "tools_test",
@@ -680,7 +860,39 @@
       "from_id": "tools_validate",
       "to_id": "doc_agent",
       "relation": "IMPLEMENTS",
-      "properties": {"scope": "Enforces TRUGS CORE rules referenced in root AGENT.md"}
+      "properties": {
+        "scope": "Enforces TRUGS CORE rules referenced in root AGENT.md"
+      }
+    },
+    {
+      "from_id": "root",
+      "to_id": "doc_contributing",
+      "relation": "CONTAINS"
+    },
+    {
+      "from_id": "root",
+      "to_id": "doc_demo",
+      "relation": "CONTAINS"
+    },
+    {
+      "from_id": "root",
+      "to_id": "doc_notice",
+      "relation": "CONTAINS"
+    },
+    {
+      "from_id": "root",
+      "to_id": "folder_brochure",
+      "relation": "CONTAINS"
+    },
+    {
+      "from_id": "root",
+      "to_id": "folder_examples",
+      "relation": "CONTAINS"
+    },
+    {
+      "from_id": "root",
+      "to_id": "folder_installers",
+      "relation": "CONTAINS"
     }
   ]
 }

--- a/installers/npm/templates/EPIC/EXAMPLE_project.trug.json
+++ b/installers/npm/templates/EPIC/EXAMPLE_project.trug.json
@@ -11,7 +11,9 @@
   },
   "capabilities": {
     "extensions": [],
-    "vocabularies": ["core_v1.0.0"],
+    "vocabularies": [
+      "core_v1.0.0"
+    ],
     "profiles": []
   },
   "nodes": [
@@ -29,7 +31,9 @@
         }
       },
       "parent_id": null,
-      "contains": ["epic_example"],
+      "contains": [
+        "epic_example"
+      ],
       "metric_level": "KILO_TRACKER",
       "dimension": "project_tracking"
     },
@@ -37,7 +41,7 @@
       "id": "epic_example",
       "type": "EPIC",
       "properties": {
-        "name": "Example Epic — Replace With Your First Initiative",
+        "name": "Example Epic \u2014 Replace With Your First Initiative",
         "purpose": "What this epic achieves and why it matters.",
         "status": "IN_PROGRESS",
         "github_issue": null,
@@ -45,7 +49,10 @@
         "created_date": "2026-04-01"
       },
       "parent_id": "tracker_root",
-      "contains": ["task_example_1", "task_example_2"],
+      "contains": [
+        "task_example_1",
+        "task_example_2"
+      ],
       "metric_level": "HECTO_EPIC",
       "dimension": "project_tracking"
     },
@@ -53,7 +60,7 @@
       "id": "task_example_1",
       "type": "TASK",
       "properties": {
-        "name": "First task — replace with real work",
+        "name": "First task \u2014 replace with real work",
         "status": "TODO",
         "github_issue": null,
         "priority": "P1"
@@ -67,7 +74,7 @@
       "id": "task_example_2",
       "type": "TASK",
       "properties": {
-        "name": "Second task — depends on first",
+        "name": "Second task \u2014 depends on first",
         "status": "TODO",
         "github_issue": null,
         "priority": "P2"
@@ -80,10 +87,12 @@
   ],
   "edges": [
     {
-      "from_id": "task_example_2",
-      "to_id": "task_example_1",
-      "relation": "BLOCKS",
-      "properties": {"description": "Task 2 cannot start until task 1 is complete"}
+      "from_id": "task_example_1",
+      "to_id": "task_example_2",
+      "relation": "DEPENDS_ON",
+      "properties": {
+        "description": "Task 2 cannot start until task 1 is complete"
+      }
     }
   ]
 }

--- a/installers/npm/templates/FOLDER/EXAMPLE_folder.trug.json
+++ b/installers/npm/templates/FOLDER/EXAMPLE_folder.trug.json
@@ -2,7 +2,7 @@
   "name": "Auth Module",
   "version": "1.0.0",
   "type": "MODULE",
-  "description": "Authentication and authorization — JWT validation, session management, role-based access control",
+  "description": "Authentication and authorization \u2014 JWT validation, session management, role-based access control",
   "dimensions": {
     "folder_structure": {
       "description": "Auth module file and component structure",
@@ -11,7 +11,9 @@
   },
   "capabilities": {
     "extensions": [],
-    "vocabularies": ["project_v1"],
+    "vocabularies": [
+      "project_v1"
+    ],
     "profiles": []
   },
   "nodes": [
@@ -20,12 +22,19 @@
       "type": "FOLDER",
       "properties": {
         "name": "auth",
-        "purpose": "Authentication and authorization module — JWT tokens, sessions, RBAC",
+        "purpose": "Authentication and authorization module \u2014 JWT tokens, sessions, RBAC",
         "verified": false,
         "stale": false
       },
       "parent_id": null,
-      "contains": ["spec_auth", "component_jwt", "component_sessions", "component_rbac", "doc_readme", "test_suite"],
+      "contains": [
+        "spec_auth",
+        "component_jwt",
+        "component_sessions",
+        "component_rbac",
+        "doc_readme",
+        "test_suite"
+      ],
       "metric_level": "KILO_FOLDER",
       "dimension": "folder_structure"
     },
@@ -34,7 +43,7 @@
       "type": "SPECIFICATION",
       "properties": {
         "name": "SPEC_auth.md",
-        "purpose": "Formal auth specification — token format, expiration rules, role hierarchy, rate limits",
+        "purpose": "Formal auth specification \u2014 token format, expiration rules, role hierarchy, rate limits",
         "format": "markdown"
       },
       "parent_id": "auth_folder",
@@ -47,7 +56,7 @@
       "type": "COMPONENT",
       "properties": {
         "name": "jwt_handler.py",
-        "purpose": "JWT token creation, validation, and refresh — HS256, 15min access / 7d refresh",
+        "purpose": "JWT token creation, validation, and refresh \u2014 HS256, 15min access / 7d refresh",
         "language": "python"
       },
       "parent_id": "auth_folder",
@@ -60,7 +69,7 @@
       "type": "COMPONENT",
       "properties": {
         "name": "sessions.py",
-        "purpose": "Server-side session store — Redis-backed, 24h TTL, sliding expiration",
+        "purpose": "Server-side session store \u2014 Redis-backed, 24h TTL, sliding expiration",
         "language": "python"
       },
       "parent_id": "auth_folder",
@@ -73,7 +82,7 @@
       "type": "COMPONENT",
       "properties": {
         "name": "rbac.py",
-        "purpose": "Role-based access control — admin/editor/viewer hierarchy, permission checks",
+        "purpose": "Role-based access control \u2014 admin/editor/viewer hierarchy, permission checks",
         "language": "python"
       },
       "parent_id": "auth_folder",
@@ -86,7 +95,7 @@
       "type": "DOCUMENT",
       "properties": {
         "name": "README.md",
-        "purpose": "Auth module quickstart — setup, configuration, usage examples",
+        "purpose": "Auth module quickstart \u2014 setup, configuration, usage examples",
         "format": "markdown"
       },
       "parent_id": "auth_folder",
@@ -99,7 +108,7 @@
       "type": "TEST_SUITE",
       "properties": {
         "name": "tests/",
-        "purpose": "Auth test suite — 43 tests covering JWT, sessions, RBAC, and integration",
+        "purpose": "Auth test suite \u2014 43 tests covering JWT, sessions, RBAC, and integration",
         "test_count": 43
       },
       "parent_id": "auth_folder",
@@ -112,56 +121,66 @@
     {
       "from_id": "component_jwt",
       "to_id": "spec_auth",
-      "relation": "implements",
-      "properties": {"scope": "JWT token format and expiration rules"}
+      "relation": "IMPLEMENTS",
+      "properties": {
+        "scope": "JWT token format and expiration rules"
+      }
     },
     {
       "from_id": "component_sessions",
       "to_id": "spec_auth",
-      "relation": "implements",
-      "properties": {"scope": "Session TTL and sliding expiration"}
+      "relation": "IMPLEMENTS",
+      "properties": {
+        "scope": "Session TTL and sliding expiration"
+      }
     },
     {
       "from_id": "component_rbac",
       "to_id": "spec_auth",
-      "relation": "implements",
-      "properties": {"scope": "Role hierarchy and permission model"}
+      "relation": "IMPLEMENTS",
+      "properties": {
+        "scope": "Role hierarchy and permission model"
+      }
     },
     {
       "from_id": "component_rbac",
       "to_id": "component_jwt",
-      "relation": "uses",
-      "properties": {"reason": "RBAC reads role claims from JWT payload"}
+      "relation": "DEPENDS_ON",
+      "properties": {
+        "reason": "RBAC reads role claims from JWT payload"
+      }
     },
     {
       "from_id": "test_suite",
       "to_id": "component_jwt",
-      "relation": "tests",
+      "relation": "REFERENCES",
       "properties": {}
     },
     {
       "from_id": "test_suite",
       "to_id": "component_sessions",
-      "relation": "tests",
+      "relation": "REFERENCES",
       "properties": {}
     },
     {
       "from_id": "test_suite",
       "to_id": "component_rbac",
-      "relation": "tests",
+      "relation": "REFERENCES",
       "properties": {}
     },
     {
       "from_id": "doc_readme",
       "to_id": "auth_folder",
-      "relation": "describes",
+      "relation": "REFERENCES",
       "properties": {}
     },
     {
       "from_id": "component_sessions",
       "to_id": "infrastructure:redis",
-      "relation": "uses",
-      "properties": {"reason": "Redis for session storage"}
+      "relation": "DEPENDS_ON",
+      "properties": {
+        "reason": "Redis for session storage"
+      }
     }
   ]
 }

--- a/installers/pip/src/trugs_agent/templates/EPIC/EXAMPLE_project.trug.json
+++ b/installers/pip/src/trugs_agent/templates/EPIC/EXAMPLE_project.trug.json
@@ -11,7 +11,9 @@
   },
   "capabilities": {
     "extensions": [],
-    "vocabularies": ["core_v1.0.0"],
+    "vocabularies": [
+      "core_v1.0.0"
+    ],
     "profiles": []
   },
   "nodes": [
@@ -29,7 +31,9 @@
         }
       },
       "parent_id": null,
-      "contains": ["epic_example"],
+      "contains": [
+        "epic_example"
+      ],
       "metric_level": "KILO_TRACKER",
       "dimension": "project_tracking"
     },
@@ -37,7 +41,7 @@
       "id": "epic_example",
       "type": "EPIC",
       "properties": {
-        "name": "Example Epic — Replace With Your First Initiative",
+        "name": "Example Epic \u2014 Replace With Your First Initiative",
         "purpose": "What this epic achieves and why it matters.",
         "status": "IN_PROGRESS",
         "github_issue": null,
@@ -45,7 +49,10 @@
         "created_date": "2026-04-01"
       },
       "parent_id": "tracker_root",
-      "contains": ["task_example_1", "task_example_2"],
+      "contains": [
+        "task_example_1",
+        "task_example_2"
+      ],
       "metric_level": "HECTO_EPIC",
       "dimension": "project_tracking"
     },
@@ -53,7 +60,7 @@
       "id": "task_example_1",
       "type": "TASK",
       "properties": {
-        "name": "First task — replace with real work",
+        "name": "First task \u2014 replace with real work",
         "status": "TODO",
         "github_issue": null,
         "priority": "P1"
@@ -67,7 +74,7 @@
       "id": "task_example_2",
       "type": "TASK",
       "properties": {
-        "name": "Second task — depends on first",
+        "name": "Second task \u2014 depends on first",
         "status": "TODO",
         "github_issue": null,
         "priority": "P2"
@@ -80,10 +87,12 @@
   ],
   "edges": [
     {
-      "from_id": "task_example_2",
-      "to_id": "task_example_1",
-      "relation": "BLOCKS",
-      "properties": {"description": "Task 2 cannot start until task 1 is complete"}
+      "from_id": "task_example_1",
+      "to_id": "task_example_2",
+      "relation": "DEPENDS_ON",
+      "properties": {
+        "description": "Task 2 cannot start until task 1 is complete"
+      }
     }
   ]
 }

--- a/installers/pip/src/trugs_agent/templates/FOLDER/EXAMPLE_folder.trug.json
+++ b/installers/pip/src/trugs_agent/templates/FOLDER/EXAMPLE_folder.trug.json
@@ -2,7 +2,7 @@
   "name": "Auth Module",
   "version": "1.0.0",
   "type": "MODULE",
-  "description": "Authentication and authorization — JWT validation, session management, role-based access control",
+  "description": "Authentication and authorization \u2014 JWT validation, session management, role-based access control",
   "dimensions": {
     "folder_structure": {
       "description": "Auth module file and component structure",
@@ -11,7 +11,9 @@
   },
   "capabilities": {
     "extensions": [],
-    "vocabularies": ["project_v1"],
+    "vocabularies": [
+      "project_v1"
+    ],
     "profiles": []
   },
   "nodes": [
@@ -20,12 +22,19 @@
       "type": "FOLDER",
       "properties": {
         "name": "auth",
-        "purpose": "Authentication and authorization module — JWT tokens, sessions, RBAC",
+        "purpose": "Authentication and authorization module \u2014 JWT tokens, sessions, RBAC",
         "verified": false,
         "stale": false
       },
       "parent_id": null,
-      "contains": ["spec_auth", "component_jwt", "component_sessions", "component_rbac", "doc_readme", "test_suite"],
+      "contains": [
+        "spec_auth",
+        "component_jwt",
+        "component_sessions",
+        "component_rbac",
+        "doc_readme",
+        "test_suite"
+      ],
       "metric_level": "KILO_FOLDER",
       "dimension": "folder_structure"
     },
@@ -34,7 +43,7 @@
       "type": "SPECIFICATION",
       "properties": {
         "name": "SPEC_auth.md",
-        "purpose": "Formal auth specification — token format, expiration rules, role hierarchy, rate limits",
+        "purpose": "Formal auth specification \u2014 token format, expiration rules, role hierarchy, rate limits",
         "format": "markdown"
       },
       "parent_id": "auth_folder",
@@ -47,7 +56,7 @@
       "type": "COMPONENT",
       "properties": {
         "name": "jwt_handler.py",
-        "purpose": "JWT token creation, validation, and refresh — HS256, 15min access / 7d refresh",
+        "purpose": "JWT token creation, validation, and refresh \u2014 HS256, 15min access / 7d refresh",
         "language": "python"
       },
       "parent_id": "auth_folder",
@@ -60,7 +69,7 @@
       "type": "COMPONENT",
       "properties": {
         "name": "sessions.py",
-        "purpose": "Server-side session store — Redis-backed, 24h TTL, sliding expiration",
+        "purpose": "Server-side session store \u2014 Redis-backed, 24h TTL, sliding expiration",
         "language": "python"
       },
       "parent_id": "auth_folder",
@@ -73,7 +82,7 @@
       "type": "COMPONENT",
       "properties": {
         "name": "rbac.py",
-        "purpose": "Role-based access control — admin/editor/viewer hierarchy, permission checks",
+        "purpose": "Role-based access control \u2014 admin/editor/viewer hierarchy, permission checks",
         "language": "python"
       },
       "parent_id": "auth_folder",
@@ -86,7 +95,7 @@
       "type": "DOCUMENT",
       "properties": {
         "name": "README.md",
-        "purpose": "Auth module quickstart — setup, configuration, usage examples",
+        "purpose": "Auth module quickstart \u2014 setup, configuration, usage examples",
         "format": "markdown"
       },
       "parent_id": "auth_folder",
@@ -99,7 +108,7 @@
       "type": "TEST_SUITE",
       "properties": {
         "name": "tests/",
-        "purpose": "Auth test suite — 43 tests covering JWT, sessions, RBAC, and integration",
+        "purpose": "Auth test suite \u2014 43 tests covering JWT, sessions, RBAC, and integration",
         "test_count": 43
       },
       "parent_id": "auth_folder",
@@ -112,56 +121,66 @@
     {
       "from_id": "component_jwt",
       "to_id": "spec_auth",
-      "relation": "implements",
-      "properties": {"scope": "JWT token format and expiration rules"}
+      "relation": "IMPLEMENTS",
+      "properties": {
+        "scope": "JWT token format and expiration rules"
+      }
     },
     {
       "from_id": "component_sessions",
       "to_id": "spec_auth",
-      "relation": "implements",
-      "properties": {"scope": "Session TTL and sliding expiration"}
+      "relation": "IMPLEMENTS",
+      "properties": {
+        "scope": "Session TTL and sliding expiration"
+      }
     },
     {
       "from_id": "component_rbac",
       "to_id": "spec_auth",
-      "relation": "implements",
-      "properties": {"scope": "Role hierarchy and permission model"}
+      "relation": "IMPLEMENTS",
+      "properties": {
+        "scope": "Role hierarchy and permission model"
+      }
     },
     {
       "from_id": "component_rbac",
       "to_id": "component_jwt",
-      "relation": "uses",
-      "properties": {"reason": "RBAC reads role claims from JWT payload"}
+      "relation": "DEPENDS_ON",
+      "properties": {
+        "reason": "RBAC reads role claims from JWT payload"
+      }
     },
     {
       "from_id": "test_suite",
       "to_id": "component_jwt",
-      "relation": "tests",
+      "relation": "REFERENCES",
       "properties": {}
     },
     {
       "from_id": "test_suite",
       "to_id": "component_sessions",
-      "relation": "tests",
+      "relation": "REFERENCES",
       "properties": {}
     },
     {
       "from_id": "test_suite",
       "to_id": "component_rbac",
-      "relation": "tests",
+      "relation": "REFERENCES",
       "properties": {}
     },
     {
       "from_id": "doc_readme",
       "to_id": "auth_folder",
-      "relation": "describes",
+      "relation": "REFERENCES",
       "properties": {}
     },
     {
       "from_id": "component_sessions",
       "to_id": "infrastructure:redis",
-      "relation": "uses",
-      "properties": {"reason": "Redis for session storage"}
+      "relation": "DEPENDS_ON",
+      "properties": {
+        "reason": "Redis for session storage"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Audit context

Round-1 weekly /audit-repos run from session-close 2026-04-11. This PR fixes 7 of the findings; the largest remaining (143 HUB-vocabulary HIGH violations in WEB_HUB/NDA graphs) is filed as a separate policy issue because it needs an HITM decision, not a mechanical rewrite.

## Findings before / after

| Severity | Before | After this PR | Remaining |
|---|---|---|---|
| CRITICAL | 0 | 0 | — |
| HIGH | 173 | 143 | tracked by follow-up issue |
| MEDIUM | 1 | 0 | — |
| LOW | 0 | 0 | — |

## What this PR does

### TRL contract violations in template files (30 edges fixed)

The 6 \`EXAMPLE_*.trug.json\` template files (3 in repo root + 3 mirrored under \`installers/npm\` and \`installers/pip\`) used non-TRL edge relations that ship to end users via the npm and pip installers. New TRUGS users were learning to write \`folder.trug.json\` with the wrong vocabulary.

Mechanical mapping (preserves semantics):

| was        | now              | reason |
|------------|------------------|--------|
| \`BLOCKS\`     | \`DEPENDS_ON\` (inverted) | A BLOCKS B → B DEPENDS_ON A; from/to swapped |
| \`implements\` | \`IMPLEMENTS\`       | case fix |
| \`uses\`       | \`DEPENDS_ON\`       | TRL preposition for usage |
| \`tests\`      | \`REFERENCES\`       | tests "reference" code under test |
| \`describes\`  | \`REFERENCES\`       | metadata reference |

30 edges rewritten across 6 files. Verified zero non-TRL relations remain in the template set.

### \`folder.trug.json\` self-description (6 missing top-level items)

Layer 4 self-description: every significant top-level item must be a node in \`folder.trug.json\`. Six were missing:

- \`CONTRIBUTING.md\` → \`doc_contributing\`
- \`DEMO.md\` → \`doc_demo\`
- \`NOTICE\` → \`doc_notice\`
- \`BROCHURE/\` → \`folder_brochure\`
- \`examples/\` → \`folder_examples\`
- \`installers/\` → \`folder_installers\`

Total: 37 → 43 nodes, 27 → 33 edges. Pure additive.

## Not in this PR

The remaining 143 HIGH violations live in \`WEB_HUB/web.trug.json\`, \`NDA/web.trug.json\`, \`NDA/epic.trug.json\`, and the 2 installer copies of WEB_HUB. They use a richer HUB-research vocabulary (\`AMPLIFIES\`, \`MOTIVATES\`, \`CONTRASTS\`, \`CONTEXTUALIZES\`, \`COMPLEMENTS\`, \`DESCRIBES\`, \`PRODUCES\`) that does not map cleanly to the TRL preposition set. A blanket rewrite to \`REFERENCES\` would lint clean but destroy the research-graph semantics.

This is a **policy decision**, not a mechanical fix. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)