### PR TITLE
fix(#1552): audit P1-2 + P2-2 — folder.trug.json + TRL→TRUG/L

### DIFF
--- a/.cursor/rules/trugs-agent.mdc
+++ b/.cursor/rules/trugs-agent.mdc
@@ -1,13 +1,13 @@
 ---
-description: TRUGS Agent — formal instruction language for LLM coding assistants (190-word TRL vocabulary)
+description: TRUGS Agent — formal instruction language for LLM coding assistants (190-word TRUG/L vocabulary)
 alwaysApply: true
 ---
 
 # TRUGS Agent
 
-You speak TRL — a 190-word formal instruction language. Every sentence compiles to a directed graph. Every word has exactly one meaning.
+You speak TRUG/L — a 190-word formal instruction language. Every sentence compiles to a directed graph. Every word has exactly one meaning.
 
-## TRL Vocabulary
+## TRUG/L Vocabulary
 
 **Nouns (graph nodes):**
 - Actors: PARTY, AGENT, PROCESS, SERVICE, FUNCTION, TRANSFORM, PRINCIPAL

--- a/examples/todo-app/app.py
+++ b/examples/todo-app/app.py
@@ -1,4 +1,4 @@
-"""Todo application with TRL-annotated functions.
+"""Todo application with TRUG/L-annotated functions.
 
 Each function has a <trl> block that specifies its exact behavior.
 The LLM reads these as formal obligations, not suggestions.
@@ -41,9 +41,9 @@ def complete_todo(todo_id: int, todos: list[dict]) -> dict:
 if __name__ == "__main__":
     store: list[dict] = []
 
-    create_todo("Learn TRL vocabulary", store)
+    create_todo("Learn TRUG/L vocabulary", store)
     create_todo("Add AGENT.md to my project", store)
-    create_todo("Write TRL specifications", store)
+    create_todo("Write TRUG/L specifications", store)
 
     complete_todo(1, store)
 

--- a/folder.trug.json
+++ b/folder.trug.json
@@ -7,6 +7,18 @@
     "folder_structure": {
       "description": "Top-level repo structure \u2014 8 component folders + tools + NDA example",
       "base_level": "BASE"
+    },
+    "documentation": {
+      "description": "Standalone docs \u2014 contributing guide, demo walkthrough, license notices, brochure",
+      "base_level": "BASE"
+    },
+    "examples": {
+      "description": "End-to-end worked examples consuming the TRUGS-AGENT primitives",
+      "base_level": "BASE"
+    },
+    "distribution": {
+      "description": "Distribution-channel installers \u2014 npm and pip packages that ship templates to end users",
+      "base_level": "BASE"
     }
   },
   "capabilities": {

--- a/installers/npm/bin/create-trugs-agent.js
+++ b/installers/npm/bin/create-trugs-agent.js
@@ -76,9 +76,9 @@ if (fs.existsSync(toolsSrc) && !fs.existsSync(toolsDest)) {
 }
 
 console.log(
-  `\nTRUGS Agent initialized for ${ide}. Your LLM now speaks TRL.`
+  `\nTRUGS Agent initialized for ${ide}. Your LLM now speaks TRUG/L.`
 );
-console.log(`  ${targetFile} — TRL vocabulary and grammar`);
+console.log(`  ${targetFile} — TRUG/L vocabulary and grammar`);
 if (copied > 0) {
   console.log(`  ${copied} component folders — methodology and tools`);
 }

--- a/installers/pip/src/trugs_agent/cli.py
+++ b/installers/pip/src/trugs_agent/cli.py
@@ -67,8 +67,8 @@ def main():
         shutil.copytree(tools_src, tools_dest)
         print("Created tools/ (validator)")
 
-    print(f"\nTRUGS Agent initialized for {args.ide}. Your LLM now speaks TRL.")
-    print(f"  {target_file} — TRL vocabulary and grammar")
+    print(f"\nTRUGS Agent initialized for {args.ide}. Your LLM now speaks TRUG/L.")
+    print(f"  {target_file} — TRUG/L vocabulary and grammar")
     if copied > 0:
         print(f"  {copied} component folders — methodology and tools")
     print("\nFull docs: https://github.com/TRUGS-LLC/TRUGS-AGENT")


### PR DESCRIPTION
## Summary
- **P1-2:** Add missing dimension declarations (documentation, examples, distribution) to folder.trug.json — fixes 6 UNDECLARED_DIMENSION validation errors
- **P2-2:** Rename bare "TRL" to "TRUG/L" in prose contexts — installer CLI output, examples, templates, docs

Tracks: Xepayac/TRUGS-DEVELOPMENT#1552

## Test plan
- [ ] `trugs-folder-check folder.trug.json` exits 0
- [ ] No broken `<trl>` tags (grep for unmatched tags)
- [ ] Installer CLI still functions correctly
- [ ] No file paths or imports changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)