### PR TITLE
chore(Xepayac/TRUGS-DEVELOPMENT#1525): CI, SECURITY.md, issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,63 @@
+name: Bug report
+description: Report a problem with the instruction templates, installers, or examples
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in the fields below. **Security vulnerabilities should not be filed here — see [SECURITY.md](../blob/main/SECURITY.md).**
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Where does the bug live?
+      options:
+        - AGENT.md (root instruction file)
+        - AAA/ (development protocol)
+        - EPIC/ (portfolio tracker)
+        - MEMORY/ (persistent context)
+        - FOLDER/ (filesystem index)
+        - TRUGGING/ (codebase description)
+        - WEB_HUB/ (web resource graph)
+        - SKILLS/ (primitives)
+        - NDA/ (worked example)
+        - examples/ (examples)
+        - installers/npm (create-trugs-agent)
+        - installers/pip (trugs-agent-init)
+        - other — specify below
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the bug. What did you do, what did you expect, what did you get?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Minimal reproduction
+      description: The smallest steps that reproduce the problem. If your LLM behaved unexpectedly, quote the exact prompt and the LLM's output.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: LLM + version (Claude Code X.Y, Cursor, Copilot, etc.), OS, install method (npm/pip/curl/git)
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Anything else — related issues, what you've tried
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/TRUGS-LLC/TRUGS-AGENT/security/advisories/new
+    about: Report security issues privately — do not open a public issue
+  - name: Question or discussion
+    url: https://github.com/TRUGS-LLC/TRUGS-AGENT/discussions
+    about: Ask a question or start a conversation
+  - name: TRUG/L vocabulary question
+    url: https://github.com/TRUGS-LLC/TRUGS/issues/new
+    about: Vocabulary or spec questions go to the TRUGS repo, not here

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: Feature request
+description: Propose a new component, skill, or installer capability
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a change. Substantive features follow the AAA protocol — this issue is the VISION step. For additions to the TRUG/L vocabulary itself, file against [`TRUGS-LLC/TRUGS`](https://github.com/TRUGS-LLC/TRUGS) instead.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What are you proposing?
+      description: Describe the feature or change in 2–3 sentences
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why does it matter?
+      description: What problem does it solve? Who benefits? What breaks without it?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other approaches did you think about? Why did you pick this one?
+    validations:
+      required: false
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope — what's in, what's out
+      description: Be explicit about what this change does NOT cover.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: compliance
+    attributes:
+      label: Compliance awareness
+      options:
+        - label: I understand `trugs-folder-check` must pass before this can merge
+          required: true
+        - label: I understand only humans merge PRs; agents open them and stop
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+<!--
+Thanks for the PR. Fill in the sections below. Delete any that don't apply.
+-->
+
+## Summary
+
+<!-- 1–3 bullet points. What changed? -->
+
+-
+-
+
+## Linked issue
+
+Fixes #<!-- issue number, if applicable. For trivial chore/docs PRs, write "none (chore)". -->
+
+## Test plan
+
+<!-- What did you do to convince yourself this works? -->
+
+- [ ] `trugs-folder-check .` reports 0 errors
+- [ ] If installer changed: `create-trugs-agent` / `trugs-agent-init` produces the expected files in a scratch directory
+- [ ] If template changed: manually validated that an LLM (Claude Code / Cursor / Copilot) follows the updated instruction correctly
+- [ ] Manual check: <!-- describe -->
+
+## AAA stage
+
+<!-- Delete if this is a pure chore/docs PR. Otherwise check the stage this PR completes. -->
+
+- [ ] CODING (phase 6)
+- [ ] TESTING (phase 7)
+- [ ] AUDIT fixes (phase 8)
+- [ ] Chore (skip AAA)
+
+## Notes for reviewers
+
+<!-- Anything non-obvious about the change, tradeoffs considered, follow-ups filed as separate issues. -->

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,0 +1,26 @@
+name: Compliance
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  folder-check:
+    runs-on: ubuntu-latest
+    name: trugs-folder-check
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install trugs
+        run: pip install trugs
+
+      - name: Validate folder.trug.json
+        run: trugs-folder-check .

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Do not open a public issue for security problems.** Instead, report privately via GitHub's security advisory workflow:
+
+1. Go to [github.com/TRUGS-LLC/TRUGS-AGENT/security/advisories/new](https://github.com/TRUGS-LLC/TRUGS-AGENT/security/advisories/new)
+2. Fill in the details: the bug, its impact, how to reproduce it
+3. We'll respond within 5 business days
+
+If you cannot use GitHub Security Advisories, email `xepayac@gmail.com` with `[TRUGS-AGENT SECURITY]` in the subject line.
+
+## What counts as a security issue
+
+TRUGS-AGENT ships agent-instruction templates and thin installers. Security issues most likely surface in:
+
+- The `installers/npm/` and `installers/pip/` packages — arbitrary file write, path traversal, or code execution during `create-trugs-agent` / `trugs-agent-init`
+- Vendored `tools/validate.py` if crafted input causes resource exhaustion or arbitrary read (upstream TRUGS — we'll forward)
+- A template file that, if followed literally by an LLM, steers it into dangerous behavior (prompt injection exposure)
+
+Bugs that are **not** security issues (just file a normal issue):
+- An installer fails on a specific OS or Node/Python version
+- A template doesn't produce the behavior you expected from your LLM
+- A broken link or typo in an agent instruction file
+
+## Supported versions
+
+TRUGS-AGENT tracks its own SemVer line, published on npm (`create-trugs-agent`) and PyPI (`trugs-agent`). Only the latest minor receives security fixes.
+
+| Version | Supported |
+|---------|-----------|
+| Latest on npm + PyPI | Yes |
+| Prior versions | No — upgrade |
+
+## Our commitment
+
+- Acknowledge receipt within 5 business days
+- Keep you informed during investigation
+- Credit you in the advisory and CHANGELOG (unless you prefer anonymity)
+- Publish a fix within 30 days for high/critical findings, or explain why more time is needed
+
+## Scope
+
+This policy covers `TRUGS-LLC/TRUGS-AGENT` — the instruction templates, installers, and documentation in this repository. For the underlying TRUGS specification and reference tools, see `TRUGS-LLC/TRUGS/SECURITY.md`.

--- a/folder.trug.json
+++ b/folder.trug.json
@@ -57,7 +57,8 @@
         "doc_notice",
         "folder_brochure",
         "folder_examples",
-        "folder_installers"
+        "folder_installers",
+        "doc_security"
       ],
       "metric_level": "KILO_FOLDER",
       "dimension": "folder_structure"
@@ -661,6 +662,19 @@
         "name": "installers",
         "purpose": "Distribution-channel installers that ship the templates and skills to end users."
       }
+    },
+    {
+      "id": "doc_security",
+      "type": "DOCUMENT",
+      "properties": {
+        "name": "SECURITY.md",
+        "purpose": "Security policy \u2014 private disclosure via GitHub Security Advisories",
+        "path": "SECURITY.md"
+      },
+      "parent_id": "root",
+      "contains": [],
+      "metric_level": "BASE_DOCUMENT",
+      "dimension": "folder_structure"
     }
   ],
   "edges": [
@@ -975,6 +989,12 @@
     {
       "from_id": "root",
       "to_id": "folder_tools",
+      "relation": "contains",
+      "properties": {}
+    },
+    {
+      "from_id": "root",
+      "to_id": "doc_security",
       "relation": "contains",
       "properties": {}
     }


### PR DESCRIPTION
## Summary

- Adds the six community-infrastructure files this repo was missing
- Brings Layer 1 (CI) + half of Layer 2 (SECURITY, templates) into compliance for #1525
- Mirrors the pattern from TRUGS#62 (same approach, adapted scope)

## Files added

| File | What it does |
|---|---|
| `.github/workflows/compliance.yml` | CI gate: installs `trugs` from PyPI, runs `trugs-folder-check .` on every push + PR |
| `SECURITY.md` | Private disclosure via GitHub Security Advisories, scoped to TRUGS-AGENT's specific attack surface |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Structured with component dropdown matching repo layout |
| `.github/ISSUE_TEMPLATE/feature_request.yml` | VISION-step form with compliance acknowledgment |
| `.github/ISSUE_TEMPLATE/config.yml` | Disables blank issues, routes security → advisories, vocabulary → TRUGS repo |
| `.github/PULL_REQUEST_TEMPLATE.md` | Summary, linked issue, compliance checklist (folder-check + installer smoke + template verify) |

## Design notes

- **CI minimal to start** — just `trugs-folder-check`. Installer tests and template-verify are manual for now; can add later without breaking this gate.
- **SECURITY.md scope is TRUGS-AGENT-specific** — attack surface is installers, vendored validator, and prompt-injection exposure. Underlying TRUGS spec issues go upstream.
- **Bug report component dropdown** — matches the 12 top-level primitives (AGENT.md, AAA, EPIC, MEMORY, FOLDER, TRUGGING, WEB_HUB, SKILLS, NDA, examples, installers) so triage is one click.
- **Config.yml routes vocabulary questions to TRUGS** — keeps this repo focused on templates/installers, the spec conversations in the spec repo.

## TRUG bookkeeping

Added `doc_security` node (DOCUMENT) + `contains` edge. `trugs-folder-check .` = 0/0.

CONTRIBUTING.md already exists in this repo, so no new doc node for that.

## Tracker

- Xepayac/TRUGS-DEVELOPMENT#1525 — P0 polish tracker for TRUGS-LLC/TRUGS-AGENT
- Layers 1 + 2 checks closed by this PR:
  - [x] CI workflow
  - [x] SECURITY.md
  - [x] Issue/PR templates

## Test plan

- [x] `trugs-folder-check .` → 0 errors / 0 warnings
- [ ] GitHub renders the issue template picker correctly (verify post-merge)
- [ ] CI runs green on first post-merge push (the compliance.yml will execute and report)
- [ ] SECURITY.md advisory link works (verify post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)