### PR TITLE
release(Xepayac/TRUGS-DEVELOPMENT#1525): v1.2.0 — polish release (all layers PASS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-04-18
+
+Polish release — all three Dark Code compliance layers PASS for `TRUGS-LLC/TRUGS-AGENT`.
+
 ### Added
-- `.github/workflows/compliance.yml` — CI gate running `trugs-folder-check` on every PR (#32)
+- `.github/workflows/compliance.yml` — CI gate validating `folder.trug.json` on every PR (#32)
 - `SECURITY.md` — private disclosure via GitHub Security Advisories (#32)
-- `.github/ISSUE_TEMPLATE/` — bug_report + feature_request + config (#32)
+- `.github/ISSUE_TEMPLATE/` — `bug_report.yml` + `feature_request.yml` + `config.yml` (#32)
 - `.github/PULL_REQUEST_TEMPLATE.md` — summary, linked issue, compliance checklist (#32)
-- This `CHANGELOG.md` — initialized retroactively after v1.1.0
+- `CHANGELOG.md` — this file, initialized retroactively after v1.1.0 (#33)
+- README mermaid architecture diagram above-the-fold showing the LLM ↔ AGENT.md ↔ TRUG/L ↔ TRUG graph ↔ validator loop (#34)
+- README "This repo, as a TRUG" section with three copy-paste queries against `folder.trug.json` (#34)
 
 ### Changed
-- `folder.trug.json` — 57 errors + 6 warnings → 0 / 0 (#31). Edge relations aligned to folder-branch vocabulary, invalid DATA node types fixed, missing `contains` edges added, name/filename alignment for 6 nodes.
-- `installers/pip/src/trugs_agent/cli.py` — added `<trl>` preamble on `main()` for Dark Code compliance (this PR)
+- `folder.trug.json` — 57 errors + 6 warnings → 0 / 0 (#31). Edge relations aligned to folder-branch vocabulary, invalid `DATA` node types fixed, missing `contains` edges added, `name`/filename alignment for 6 nodes.
+- `installers/pip/src/trugs_agent/cli.py` — added `<trl>` preamble on `main()` for Dark Code compliance (#33)
+- `installers/pip/pyproject.toml` — version 1.1.0 → 1.2.0 (this release)
+- `installers/npm/package.json` — version 1.0.0 → 1.2.0 (this release; synchronizes with pip)
+
+### Release discipline
+- Retroactive GitHub Release cut for this version (the first one; 1.0.0 and 1.1.0 shipped to PyPI only). Going forward, every version bump creates a corresponding git tag and GitHub Release.
 
 ### Context
-- Work tracked under `Xepayac/TRUGS-DEVELOPMENT#1525` (P0 polish for TRUGS-LLC/TRUGS-AGENT). Goal: all three polish layers PASS. EPIC: `Xepayac/TRUGS-DEVELOPMENT#1548` (Bring TRUGS-LLC public portfolio to Dark Code compliance).
+- Work tracked under `Xepayac/TRUGS-DEVELOPMENT#1525` (P0 polish for `TRUGS-LLC/TRUGS-AGENT`). EPIC: `Xepayac/TRUGS-DEVELOPMENT#1548` (Bring TRUGS-LLC public portfolio to Dark Code compliance).
+- Follow-up: `Xepayac/TRUGS-DEVELOPMENT#1567` — publish `trugs-tools` to PyPI so CI can restore the full `trugs-folder-check` (currently uses an inline Python fallback).
 
 ## [1.1.0] - 2026-04-08
 

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-trugs-agent",
-  "version": "1.0.0",
-  "description": "Initialize TRUGS Agent in your project — a 190-word formal instruction language for LLM coding assistants",
+  "version": "1.2.0",
+  "description": "Initialize TRUGS Agent in your project \u2014 a 190-word formal instruction language for LLM coding assistants",
   "bin": {
     "create-trugs-agent": "./bin/create-trugs-agent.js"
   },

--- a/installers/pip/pyproject.toml
+++ b/installers/pip/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trugs-agent"
-version = "1.1.0"
+version = "1.2.0"
 description = "Initialize TRUGS Agent in your project — a 190-word formal instruction language for LLM coding assistants"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Promotes the #1525 polish-chain work into a shipped v1.2.0 release.

- `installers/pip/pyproject.toml`: **1.1.0 → 1.2.0**
- `installers/npm/package.json`: **1.0.0 → 1.2.0** (synchronizes with pip — was behind by one minor)
- `CHANGELOG.md`: `[Unreleased]` → `[1.2.0] - 2026-04-18` with the full changelist

## What's in v1.2.0

The polish chain across four PRs:

| PR | Layer | Contribution |
|---|---|---|
| #31 | 3 | folder.trug.json — 57 errors + 6 warnings → 0 / 0 |
| #32 | 1+2 | CI compliance workflow, SECURITY.md, issue/PR templates |
| #33 | 2+3 | CHANGELOG init, `<trl>` preamble on cli.main, CI fix (inline JSON check pending trugs-tools on PyPI) |
| #34 | 2+3 | README mermaid architecture diagram + "This repo, as a TRUG" dogfooding section |

Net: all three Dark Code compliance layers pass for this repo.

## Post-merge actions (one command each)

```bash
# Tag the release
git tag v1.2.0

# Push the tag
git push origin v1.2.0

# Cut the GitHub Release with notes from the CHANGELOG
gh release create v1.2.0 --title "TRUGS Agent v1.2.0 — Polish Release" \
  --notes-file CHANGELOG.md  # extract [1.2.0] section
```

I can run these post-merge if you want; they don't need a separate PR.

## Version synchronization note

Prior state had pip at 1.1.0 and npm at 1.0.0. This PR lands them both at 1.2.0 so they move together going forward. The npm 1.1.0 version was never published; the jump from 1.0.0 → 1.2.0 skips a minor but stays within SemVer discipline.

## Tracker

- Xepayac/TRUGS-DEVELOPMENT#1525 — P0 polish tracker
- Layer 2 checks closed by this release:
  - [x] CHANGELOG.md + SemVer tags + GitHub Releases (post-merge tag + release completes the last item)

## Test plan

- [x] Inline compliance check passes (folder.trug.json still 0/0, 45 nodes, 47 edges)
- [ ] CI passes on this PR
- [ ] After merge: tag + release cut, both render on GitHub
- [ ] Next PyPI/npm publish cycle ships v1.2.0 to the registries

## Follow-up filed

- Xepayac/TRUGS-DEVELOPMENT#1567 — publish `trugs-tools` to PyPI so CI can restore the full `trugs-folder-check` (currently uses an inline Python fallback in compliance.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)