### PR TITLE
chore(audit): index PROPOSAL/ in folder.trug.json (release polish #2616)

### DIFF
--- a/folder.trug.json
+++ b/folder.trug.json
@@ -53,6 +53,7 @@
         "doc_notice",
         "folder_brochure",
         "folder_examples",
+        "folder_proposal",
         "doc_security",
         "doc_changelog"
       ],
@@ -671,6 +672,19 @@
       "contains": [],
       "metric_level": "BASE_DOCUMENT",
       "dimension": "folder_structure"
+    },
+    {
+      "id": "folder_proposal",
+      "type": "FOLDER",
+      "parent_id": "root",
+      "contains": [],
+      "metric_level": "KILO_FOLDER",
+      "dimension": "documentation",
+      "properties": {
+        "path": "PROPOSAL/",
+        "name": "PROPOSAL",
+        "purpose": "Design proposals — graph-first development with the trugs-agent developer tutorial (#1432)."
+      }
     }
   ],
   "edges": [
@@ -992,6 +1006,12 @@
     {
       "from_id": "root",
       "to_id": "doc_changelog",
+      "relation": "contains",
+      "properties": {}
+    },
+    {
+      "from_id": "root",
+      "to_id": "folder_proposal",
       "relation": "contains",
       "properties": {}
     }


### PR DESCRIPTION
## Release-polish audit finding (MEDIUM)

Surfaced by the weekly `/audit-repos` release-polish sweep tracked at **Xepayac/TRUGS-DEVELOPMENT#2616** (Run 1 — flagship cohort).

**Finding (Layer 4 — self-description):** the `PROPOSAL/` directory (graph-first development tutorial, #1432) exists on disk but had **no node** in `folder.trug.json`, so the repo's self-graph was incomplete.

**Fix:** add a `FOLDER` node (`folder_proposal`) + `contains` edge, modeled on the existing `folder_brochure`/`folder_examples` pattern. Re-validates **VALID** via `tg validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)