### PR TITLE
docs: under-reconstruction banner — repo NOT working + new examples/tutorials vision

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,25 @@
 
 # TRUGS Agent
 
+> ## 🚧 Under reconstruction — this repo is NOT currently working
+>
+> **TRUGS-AGENT is being rebuilt and is not in a functional state right now.** The previous
+> installable-kit version is frozen and unmaintained — its install instructions, version
+> numbers, and bundled artifacts **do not reflect a working product and should not be relied
+> on** (for example, the canonical `AAA/AAA_REFERENCE_for_LLM.trug.json` does not currently
+> validate). **Treat everything below this banner as legacy and possibly inaccurate** until
+> the rebuild ships.
+>
+> **New direction:** TRUGS-AGENT is becoming a curated collection of **examples and tutorials
+> that show how to use TRUGS / TRL** — no pip package, no npm package, no installable
+> components; just worked examples you read, run, and copy. That rebuild is in progress and
+> has **not shipped yet**.
+>
+> **In the meantime:** for the working toolchain use
+> [`trugs-tools`](https://github.com/TRUGS-LLC/TRUGS-TOOLS) (`pip install trugs-tools` → the
+> `tg` CLI); for the language and reference spec see
+> [`TRUGS`](https://github.com/TRUGS-LLC/TRUGS).
+
 **Your LLM ignores your system prompt because English is ambiguous. TRUGS Agent gives it a formal instruction language instead.**
 
 TRUG/L (TRUGS Language) has 190 words. Every sentence has exactly one meaning. Every instruction compiles to a verifiable graph. Your AI coding assistant stops interpreting and starts executing.


### PR DESCRIPTION
## What

Adds a prominent above-the-fold banner to `README.md` that states honestly:

- **This repo is NOT currently working** — the frozen installable-kit version is unmaintained; install instructions, version numbers, and bundled artifacts are stale (e.g. `AAA/AAA_REFERENCE_for_LLM.trug.json` does not validate).
- **New direction:** TRUGS-AGENT is being rebuilt as a **collection of examples and tutorials for using TRUGS / TRL** — no installable components.
- The rebuild is **in progress and not yet shipped**; it lives in the private `TRUGS-AGENT-dev` (tracked by `Xepayac/TRUGS-DEVELOPMENT#2276`).
- Points readers to the working surfaces in the meantime: [`trugs-tools`](https://github.com/TRUGS-LLC/TRUGS-TOOLS) and [`TRUGS`](https://github.com/TRUGS-LLC/TRUGS).

## Why

The repo is mid-pivot. Rather than polish an artifact the rebuild will replace, this keeps the public repo **honest and non-misleading** while staying public (so inbound links — incl. the just-shipped flagship `TRUGS` README — don't break). Supersedes the polish plan `Xepayac/TRUGS-DEVELOPMENT#2734`, which is being closed in favor of the build AAA (#2276).

## Scope

README banner only. No code, no graph edits, no version changes — the rebuild owns all of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)