### PR TITLE
chore: fix the public quickstart — there is no public `tg` binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Per TRUGS-LLC reorganization EPIC [`Xepayac/TRUGS-DEVELOPMENT#1576`](https://git
 
 - `trugs-agent` 1.2.0 remains on PyPI indefinitely (PyPI immutability) but will **not** receive updates.
 - `create-trugs-agent` (npm) was never published; the `installers/` directory has been removed from this repo.
-- CLI automation has moved to the sibling package [`trugs-tools`](https://github.com/TRUGS-LLC/TRUGS-TOOLS) — `pip install trugs-tools` provides the `tg` binary with 36 operations.
+- CLI automation has moved to the sibling packages — `pip install trugs-tools` provides the **`trug`** binary (8 verbs), and `pip install trugs-folder` provides **`trug-a-folder`** (14 verbs). There is no public `tg` binary.
 
 ### Added
 - `AAA/GUIDE_aaa_workflow_for_llm_agents.md` — 21 KB workflow deep-dive migrated from `Xepayac/TRUGS-AAA` (now archived).

--- a/README.md
+++ b/README.md
@@ -75,11 +75,13 @@ curl -o CLAUDE.md https://raw.githubusercontent.com/TRUGS-LLC/TRUGS-AGENT/main/A
 
 **Already using Cursor?** This repo includes `.cursor/rules/trugs-agent.mdc` — clone the repo and copy the `.cursor/` directory into your project.
 
-**Want the CLI automation?** Install the sibling [`trugs-tools`](https://github.com/TRUGS-LLC/TRUGS-TOOLS) package — it provides the unified `tg` binary for validation, graph operations, memory, AAA protocol checks, and more:
+**Want the CLI automation?** Install the sibling packages — `trugs-tools` provides the **`trug`** binary (validate, compile TRL, graph reads/writes), and `trugs-folder` provides **`trug-a-folder`** (filesystem ↔ graph cartography):
 
 ```bash
-pip install trugs-tools
-tg --help   # 36 operations under 21 top-level verbs + 3 sub-namespaces
+pip install trugs-tools trugs-folder
+
+trug --help            # 8 verbs: validate · trl · get · update · delete · unlink · compliance · audit
+trug-a-folder --help   # 14 verbs: init · check · sync · render · info · ls · where · find · …
 ```
 
 ### Legacy — `pip install trugs-agent` (frozen at 1.2.0)
@@ -143,13 +145,13 @@ This repository describes itself as a TRUG. [`folder.trug.json`](folder.trug.jso
 
 ```bash
 # What components does this repo ship?
-tg ls folder.trug.json
+trug-a-folder ls .
 
 # What does the AAA component depend on?
-tg get folder.trug.json aaa_agent --edges
+trug get folder.trug.json aaa_agent --edges
 
 # Does the graph match the filesystem?
-tg check .
+trug-a-folder check .
 ```
 
 CI runs a folder-check on every PR. When the graph drifts from prose or filesystem, CI fails. We eat our own dog food — the tool we tell you to use on your projects, we use on ours.


### PR DESCRIPTION
## The bug

The README's **first command** is broken. It says:

```bash
pip install trugs-tools
tg --help
```

**`trugs-tools` does not ship a `tg`.** It ships **`trug`**. Every visitor who copy-pastes the quickstart hits `command not found` on their very first command — today, on public `main`.

`tg` is the **private internal forge binary**. It has never been public.

## The real public surface (verified against the published wheels, not from memory)

| Package | Console script | Verbs |
|---|---|---|
| `trugs-tools` | **`trug`** | 8 — validate · trl · get · update · delete · unlink · compliance · audit |
| `trugs-folder` | **`trug-a-folder`** | 14 — init · check · sync · render · info · ls · where · find · … |

## Also corrected while here

- *"the unified `tg` binary for validation, graph operations, **memory, AAA protocol checks**"* — the public tools do **neither**. Those are private forge capabilities.
- *"36 operations under 21 top-level verbs + 3 sub-namespaces"* — actually **22 verbs across two binaries**. Re-derived from `--help` on the real wheels.
- **`trugs-folder` was never mentioned at all** — so the folder-cartography examples (`ls`, `check`) could not have worked even with the right binary name.

## Not a rename — a trap avoided

`tg ls folder.trug.json` → **`trug-a-folder ls .`**

`trug-a-folder ls` takes a **directory**, not a graph file. A naive `tg`→`trug` sweep would have produced a *second* broken command. Every example below was executed, not assumed.

## Verification

Clean venv, **no `tg` on PATH**, installing exactly what the README now tells a stranger to install:

```
tg absent ✓

  trug --help                                   ✅
  trug-a-folder --help                          ✅
  trug-a-folder ls .                            ✅
  trug get folder.trug.json aaa_agent --edges   ✅
  trug-a-folder check .                         ✅
```

A stranger's copy-paste now works end to end.

## Scope — deliberately narrow

This fixes the **first-contact** surface only (`README.md`, `CHANGELOG.md`).

A full sweep of the private `tg` across `FOLDER/`, `SKILLS/`, `AAA/`, the PR/issue templates and **`.github/workflows/compliance.yml`** is **not a chore** and is explicitly out of scope:

- **`tg aaa generate`** (in `AAA/GUIDE_*.md`, `AAA_REFERENCE_for_LLM.trug.json`) is a **RETIRED** capability with **no public equivalent** — what to say instead is a judgment call, not a rename.
- **`compliance.yml` runs `tg check`** — that is executable CI, so changing it changes behavior.

11 files, 30+ occurrences. That belongs to the graduation cutover (`TRUGS-AGENT-dev#33`), which owns the public swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)