### PR TITLE
chore: the banner ALSO pointed at the nonexistent `tg` CLI (follow-up to #40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@
 >
 > **In the meantime:** for the working toolchain use
 > [`trugs-tools`](https://github.com/TRUGS-LLC/TRUGS-TOOLS) (`pip install trugs-tools` → the
-> `tg` CLI); for the language and reference spec see
+> **`trug`** CLI) and `trugs-folder` (`pip install trugs-folder` → **`trug-a-folder`**, for
+> filesystem ↔ graph cartography); for the language and reference spec see
 > [`TRUGS`](https://github.com/TRUGS-LLC/TRUGS).
 
 **Your LLM ignores your system prompt because English is ambiguous. TRUGS Agent gives it a formal instruction language instead.**


### PR DESCRIPTION
## What #40 missed

#40 fixed the quickstart. **It missed the banner** — and the banner is the worse of the two.

```
> **In the meantime:** for the working toolchain use
> [`trugs-tools`] (`pip install trugs-tools` → the `tg` CLI);
```

**Why this instance is worse than the one #40 fixed:** the under-reconstruction banner sits **above the fold** and **outside its own disclaimer** — it explicitly tells readers *"treat everything **below this banner** as legacy and possibly inaccurate."* So the banner reads as the **one piece of currently-valid advice on the page**. And it pointed at a binary that does not exist.

## Why I missed it

My verification grep in #40 matched `tg` only as an **invocation** (`^tg ` or `` `tg <verb>` ``). The banner uses the **prose** form — *"the `tg` CLI"* — with no verb after it. The regex was too narrow, and I reported the defect as fully gone when it wasn't.

Re-checked here with a plain word-boundary grep (`grep -nw 'tg'`), which is what I should have used the first time. **`README.md` now contains zero occurrences of the private `tg`.**

## The fix

The banner now names **both** public packages and **both** real binaries:

| Package | Binary |
|---|---|
| `trugs-tools` | **`trug`** |
| `trugs-folder` | **`trug-a-folder`** (filesystem ↔ graph cartography) |

`trugs-folder` was never mentioned anywhere in the banner — so even a reader who guessed the right binary name still couldn't run the folder commands.

## Verification

Clean venv, **no `tg` on PATH**, installing exactly the two packages the banner now names:

```
tg absent ✓
✅ trug            (from pip install trugs-tools)
✅ trug-a-folder   (from pip install trugs-folder)
```

## Still out of scope (unchanged from #40)

The remaining ~30 `tg` occurrences across `FOLDER/`, `SKILLS/`, `AAA/`, the PR/issue templates and `.github/workflows/compliance.yml` are **not** a mechanical rename (`tg aaa generate` is a *retired* capability with no public equivalent; `compliance.yml` is executable CI). Tracked on `TRUGS-AGENT-dev#33`, which owns the public cutover.

**Also noted, not fixed here:** the README still claims TRUG/L has **"190 words"** (lines 31, 123). The current substrate is **233**. That is a stale-v1 claim already on #31's sweep list and #19's G5 gate — it belongs to the graduation, not to a first-contact chore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)