### PR TITLE
fix: migrate the 4 public v1 graphs to core_v2.0.0 (Xepayac/TRUGS-DEVELOPMENT#3086)

### DIFF
--- a/EPIC/EXAMPLE_project.trug.json
+++ b/EPIC/EXAMPLE_project.trug.json
@@ -12,7 +12,7 @@
   "capabilities": {
     "extensions": [],
     "vocabularies": [
-      "core_v1.0.0"
+      "core_v2.0.0"
     ],
     "profiles": []
   },

--- a/NDA/epic.trug.json
+++ b/NDA/epic.trug.json
@@ -12,7 +12,7 @@
   "capabilities": {
     "extensions": [],
     "vocabularies": [
-      "core_v1.0.0"
+      "core_v2.0.0"
     ],
     "profiles": []
   },

--- a/NDA/nda.trug.json
+++ b/NDA/nda.trug.json
@@ -11,7 +11,7 @@
   },
   "capabilities": {
     "extensions": [],
-    "vocabularies": ["core_v1.0.0"],
+    "vocabularies": ["core_v2.0.0"],
     "profiles": []
   },
   "nodes": [

--- a/examples/todo-app/folder.trug.json
+++ b/examples/todo-app/folder.trug.json
@@ -11,7 +11,7 @@
   },
   "capabilities": {
     "extensions": [],
-    "vocabularies": ["core_v1.0.0"],
+    "vocabularies": ["core_v2.0.0"],
     "profiles": []
   },
   "nodes": [


### PR DESCRIPTION
## What

TRUGS CORE v1.0 is retired (HITM ruling 2026-07-13). The published `trug` validator (**trugs-tools 2.1.0**) now **rejects** any graph declaring `core_v1.0.0` (`RETIRED_VOCABULARY`). These four public graphs still declared pure v1 → **INVALID** under the shipped tool:

| Graph | What it is |
|---|---|
| `NDA/nda.trug.json` | the flagship "Mutual NDA for TRUGS LLC" product graph |
| `NDA/epic.trug.json` | its epic |
| `EPIC/EXAMPLE_project.trug.json` | worked EPIC example |
| `examples/todo-app/folder.trug.json` | todo-app demo folder graph |

Per the issue ("they graduate or they go") these **graduate**: `core_v1.0.0` → `core_v2.0.0` in `capabilities.vocabularies`, one line each.

## Verification
Each is **VALID** under the full v2 tier (9 structural + 7 compositional) — checked with the published `trug validate`. No other structural change was needed (these graphs were already v2-shaped; only the vocabulary string was stale).

## Scope
This is the **graph-strip** leg of #3086. A fresh 18-repo fleet census (2026-07-18) confirms these 4 are the **only** real, hand-editable, shippable `core_v1.0.0`-declaring graphs outstanding. The rest are intentionally-invalid audit RED fixtures (#3071 — kept), archived/gitignored, or v1 migration-test *inputs* — all correctly left as-is. The back-compat *code* removal, the `tg` tombstone, and the `trugs-agent` PyPI decision are separate legs tracked on #3086.

🤖 Generated with [Claude Code](https://claude.com/claude-code)