### PR TITLE
fix(docs): CLI provenance honesty — trug-a-folder renames + drop private tg verbs (#3068)

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -44,7 +44,7 @@ body:
     attributes:
       label: Compliance awareness
       options:
-        - label: I understand `tg check` must pass before this can merge
+        - label: I understand `trug-a-folder check` must pass before this can merge
           required: true
         - label: I understand only humans merge PRs; agents open them and stop
           required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@ Fixes #<!-- issue number, if applicable. For trivial chore/docs PRs, write "none
 
 <!-- What did you do to convince yourself this works? -->
 
-- [ ] `tg check .` reports 0 errors
+- [ ] `trug-a-folder check .` reports 0 errors
 - [ ] If installer changed: `create-trugs-agent` / `trugs-agent-init` produces the expected files in a scratch directory
 - [ ] If template changed: manually validated that an LLM (Claude Code / Cursor / Copilot) follows the updated instruction correctly
 - [ ] Manual check: <!-- describe -->

--- a/AAA/AAA_REFERENCE_for_LLM.trug.json
+++ b/AAA/AAA_REFERENCE_for_LLM.trug.json
@@ -106,7 +106,7 @@
       "parent_id": "aaa_framework",
       "properties": {
         "name": "Lifecycle: From Idea to Agent Execution",
-        "steps": ["Developer writes documents on disk (VISION_*, RESEARCH_*, SPEC_*, PROPOSAL_*)", "Developer consolidates into GitHub Issue (9-phase AAA format)", "Nightly pipeline (tg aaa generate) writes issue body to FOLDERNAME/AAA.md", "Agent reads folder.trug.json + AAA.md, implements, updates TRUG, creates PR"],
+        "steps": ["Developer writes documents on disk (VISION_*, RESEARCH_*, SPEC_*, PROPOSAL_*)", "Developer consolidates into GitHub Issue (9-phase AAA format)", "Issue body is placed as FOLDERNAME/AAA.md (a prompt-protocol step by developer or agent, not a program)", "Agent reads folder.trug.json + AAA.md, implements, updates TRUG, creates PR"],
         "agent_workflow": ["Read folder.trug.json", "Read AAA.md", "Implement", "Update folder.trug.json", "Create PR"]
       },
       "contains": [],
@@ -159,9 +159,9 @@
       "metric_level": "BASE_CONCEPT",
       "parent_id": "aaa_framework",
       "properties": {
-        "name": "Nightly Pipeline",
+        "name": "Folder-Maintenance Pipeline",
         "workflow_file": ".github/workflows/folder-sync.yml",
-        "steps": ["tg aaa generate", "tg sync", "tg check", "tg render", "tg info", "change_summary.py", "git commit + push", "Error issue"]
+        "steps": ["trug-a-folder sync", "trug-a-folder check", "trug-a-folder render", "change_summary.py", "git commit + push", "Error issue"]
       },
       "contains": [],
       "dimension": "aaa_structure"

--- a/AAA/GUIDE_aaa_workflow_for_llm_agents.md
+++ b/AAA/GUIDE_aaa_workflow_for_llm_agents.md
@@ -137,16 +137,16 @@ The working documents on disk either:
 - Get archived with `zzz_` prefix when superseded by the issue content
 - Stay as-is until the issue is completed
 
-### Step 3: Nightly pipeline generates AAA.md
+### Step 3: The issue body becomes the folder's AAA.md
 
-A nightly workflow (`tg aaa generate`) scans all open GitHub Issues for `folder:FOLDERNAME` labels and writes the issue body to `FOLDERNAME/AAA.md` on disk.
+AAA is a **prompt protocol, not a program** — no binary generates plans. The issue body *is* the plan; it reaches the agent by being placed as `FOLDERNAME/AAA.md` on disk. For an issue carrying a `folder:FOLDERNAME` label, the developer (or the agent itself, when asked) copies the issue body into that folder.
 
 ```
 GitHub Issue #612 (labeled folder:TRUGS_COMPUTATION)
     │
-    ▼  nightly tg aaa generate
+    ▼  copy the issue body into the folder
     │
-TRUGS_COMPUTATION/AAA.md  (read-only, auto-generated)
+TRUGS_COMPUTATION/AAA.md  (the plan the agent reads)
 ```
 
 **Key rules:**
@@ -197,7 +197,7 @@ These improve the specification itself. The work is: edit the GitHub Issue body 
 
 Example: *"Phase 2 FEASIBILITY: Complete external research for PERAGO v2.0"*
 
-After the edit, the nightly pipeline regenerates `AAA.md`. Type A sub-issues don't carry a `folder:` label themselves.
+After the edit, the updated issue body is re-placed as `AAA.md` in the folder (Step 3). Type A sub-issues don't carry a `folder:` label themselves.
 
 ### Type B — Code Development Sub-Issues
 
@@ -370,7 +370,7 @@ This is the `aaa_v1` vocabulary:
 
 Edge relations include `precedes`, `depends_on`, `blocked_by`, `mitigates`, `validates`, `tracks`, `cites`, `decides`, `implements`.
 
-The benefit: the nightly pipeline can validate the graph structure (all node IDs exist, edges point to real nodes, required properties present) *before* rendering `AAA.md`. Bad data is caught at write time, not at agent-execution time.
+The benefit: `trug-a-folder check` validates the graph structure (all node IDs exist, edges point to real nodes, required properties present) *before* the folder's `ARCHITECTURE.md` is rendered. Bad data is caught at write time, not at agent-execution time.
 
 ---
 
@@ -404,25 +404,20 @@ Research depth scales with difficulty:
 
 ---
 
-## The Nightly Pipeline
+## The Folder-Maintenance Pipeline
 
-The full nightly sequence (`.github/workflows/folder-sync.yml`, 07:00 UTC daily):
+The nightly folder-cartography sequence (`.github/workflows/folder-sync.yml`, 07:00 UTC daily) keeps each folder's structural graph in sync with disk:
 
 ```
-1. tg aaa generate     → Write AAA.md from GitHub Issues
-2. tg sync      → Sync folder.trug.json stale flags
-3. tg check     → Validate all TRUGs (continue on error)
-4. tg render    → Regenerate all ARCHITECTURE.md
-5. tg info       → Build root cross-folder graph
-6. change_summary.py      → Generate change summary
-7. git commit + push      → Commit all generated changes
-8. Error issue (if any)   → Open issue for pipeline errors
+1. trug-a-folder sync     → Sync folder.trug.json stale flags
+2. trug-a-folder check    → Validate all TRUGs (continue on error)
+3. trug-a-folder render   → Regenerate all ARCHITECTURE.md
+4. change_summary.py      → Generate change summary
+5. git commit + push      → Commit all generated changes
+6. Error issue (if any)   → Open issue for pipeline errors
 ```
 
-**Manual trigger:**
-```bash
-tg aaa generate --root .
-```
+Placing an issue body as a folder's `AAA.md` (Step 3 above) is a **prompt-protocol** step performed by the developer or agent — it is not part of this maintenance pipeline.
 
 ---
 
@@ -481,7 +476,7 @@ Human develops VISION_*, FEASIBILITY_*, SPEC_* docs on disk
     ↓
 Human consolidates into GitHub Issue (9-phase AAA format)
     ↓
-Nightly pipeline generates AAA.md in the folder
+Issue body placed as AAA.md in the folder
     ↓
 Agent reads folder.trug.json + AAA.md
     ↓

--- a/FOLDER/AGENT.md
+++ b/FOLDER/AGENT.md
@@ -203,7 +203,7 @@ AGENT SHALL VALIDATE FILE folder.trug.json.
 3. **Create a node for each file/component** — type it correctly, write a one-sentence purpose
 4. **Set hierarchy** — `parent_id` points up, `contains` points down, both must agree
 5. **Create edges** — `implements`, `tests`, `uses`, `describes`, etc.
-6. **Validate** — run `tg check` or `trug validate`
+6. **Validate** — run `trug-a-folder check` or `trug validate`
 
 ---
 
@@ -289,20 +289,20 @@ Files prefixed with `zzz_` are archived — pending human review before deletion
 ## CLI Tools
 
 <trl>
-AGENT MAY USE RECORD command "tg init" TO CREATE FILE folder.trug.json FROM RECORD filesystem.
-AGENT MAY USE RECORD command "tg sync" TO UPDATE FILE folder.trug.json FROM RECORD filesystem.
-AGENT SHALL USE RECORD command "tg check" TO VALIDATE FILE folder.trug.json.
-AGENT MAY USE RECORD command "tg render" TO GENERATE FILE ARCHITECTURE.md FROM FILE folder.trug.json.
+AGENT MAY USE RECORD command "trug-a-folder init" TO CREATE FILE folder.trug.json FROM RECORD filesystem.
+AGENT MAY USE RECORD command "trug-a-folder sync" TO UPDATE FILE folder.trug.json FROM RECORD filesystem.
+AGENT SHALL USE RECORD command "trug-a-folder check" TO VALIDATE FILE folder.trug.json.
+AGENT MAY USE RECORD command "trug-a-folder render" TO GENERATE FILE ARCHITECTURE.md FROM FILE folder.trug.json.
 </trl>
 
 ```bash
-tg init [PATH]              # Generate starter folder.trug.json from directory scan
-tg sync [PATH] [--all]      # Add nodes for new files, mark missing files stale
-tg check [PATH] [--all]     # Validate folder.trug.json — exit 0 = pass, exit 1 = errors
-tg render [PATH] [--all]    # Regenerate ARCHITECTURE.md from folder.trug.json
+trug-a-folder init [PATH]              # Generate starter folder.trug.json from directory scan
+trug-a-folder sync [PATH] [--all]      # Add nodes for new files, mark missing files stale
+trug-a-folder check [PATH] [--all]     # Validate folder.trug.json — exit 0 = pass, exit 1 = errors
+trug-a-folder render [PATH] [--all]    # Regenerate ARCHITECTURE.md from folder.trug.json
 ```
 
-`tg sync` rules:
+`trug-a-folder sync` rules:
 - Adds nodes for new files found on disk
 - Sets `stale: true` on nodes whose files are missing
 - Never removes nodes

--- a/FOLDER/README.md
+++ b/FOLDER/README.md
@@ -63,10 +63,10 @@ Each node has a `purpose` field — one sentence explaining what the file does. 
 ## CLI Tools
 
 ```bash
-tg init [PATH]    # Generate starter folder.trug.json from directory scan
-tg sync [PATH]    # Update nodes for new/missing files
-tg check [PATH]   # Validate folder.trug.json — exit 0 = pass
-tg render [PATH]  # Regenerate ARCHITECTURE.md from folder.trug.json
+trug-a-folder init [PATH]    # Generate starter folder.trug.json from directory scan
+trug-a-folder sync [PATH]    # Update nodes for new/missing files
+trug-a-folder check [PATH]   # Validate folder.trug.json — exit 0 = pass
+trug-a-folder render [PATH]  # Regenerate ARCHITECTURE.md from folder.trug.json
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ trug --help            # 8 verbs: validate · trl · get · update · delete · 
 trug-a-folder --help   # 14 verbs: init · check · sync · render · info · ls · where · find · …
 ```
 
-### Legacy — `pip install trugs-agent` (frozen at 1.2.0)
+### Legacy — `pip install trugs-agent` (frozen at 1.1.0)
 
-The npm `create-trugs-agent` package was never published. The `pip install trugs-agent` package is frozen at 1.2.0 — it still installs but ships pre-1.0 shadow-copy templates and does not receive updates. **For current content, `git clone` this repo.**
+The npm `create-trugs-agent` package was never published. The `pip install trugs-agent` package is frozen at 1.1.0 — it still installs but ships pre-1.0 shadow-copy templates and does not receive updates. **For current content, `git clone` this repo.**
 
 **Validate your TRUGs** — with `trug` from `trugs-tools` (installed above):
 

--- a/SKILLS/AGENT.md
+++ b/SKILLS/AGENT.md
@@ -101,7 +101,7 @@ FUNCTION trug-sync SHALL MARK RECORD node AS PENDING IF FILE 'is 'not FOUND.
 FUNCTION trug-sync SHALL_NOT REPLACE ANY RECORD node.
 </trl>
 
-Run `tg sync` on a folder. Adds nodes for new files, marks missing files stale. Never removes nodes.
+Run `trug-a-folder sync` on a folder. Adds nodes for new files, marks missing files stale. Never removes nodes.
 
 <trl>
 DEFINE "trug-check" AS FUNCTION.
@@ -110,7 +110,7 @@ FUNCTION trug-check SHALL RESPOND 'with RECORD result AS VALID OR INVALID.
 IF RECORD result 'is INVALID THEN FUNCTION trug-check SHALL RESPOND 'with EACH RECORD error.
 </trl>
 
-Run `tg check` to validate a folder.trug.json against structural rules. Returns pass/fail with error details.
+Run `trug-a-folder check` to validate a folder.trug.json against structural rules. Returns pass/fail with error details.
 
 <trl>
 DEFINE "trug-clean" AS FUNCTION.


### PR DESCRIPTION
Closes part of #3068 (Leg A — TRUGS-AGENT surfaces) and applies the Q1-approved unmappable-verb deletions.

## What changed
- **README** — corrected the legacy-package frozen version: `1.2.0` → `1.1.0` in both the heading and body (PyPI `trugs-agent` ships only 1.0.0 and 1.1.0; 1.2.0 never existed — a factual fix).
- **Folder-verb renames** (`tg init|sync|check|render` → `trug-a-folder <verb>`, cleanly mappable folder-cartography verbs):
  - `.github/PULL_REQUEST_TEMPLATE.md`, `.github/ISSUE_TEMPLATE/feature_request.yml`
  - `FOLDER/AGENT.md` (normative TRL command strings + bash block + validate step), `FOLDER/README.md`
  - `SKILLS/AGENT.md`
  - `AAA/GUIDE_aaa_workflow_for_llm_agents.md` + `AAA/AAA_REFERENCE_for_LLM.trug.json`
- **Unmappable private-forever deletions** (`tg aaa generate`, `tg info`) per the Q1 ruling — *"AAA is a prompt protocol, not a program."* The AAA guide is rewritten so the issue body is **placed** as `AAA.md` by the developer or agent (a prompt-protocol step), not auto-generated by a binary; the "Nightly Pipeline" is retitled the folder-maintenance pipeline and no longer claims to generate plans. `AAA_REFERENCE_for_LLM.trug.json` re-validates **VALID**.

## Verification
`grep -rnE '\btg (aaa|info|memory|check|sync|render|init|validate|compliance)\b' README.md SKILLS/ FOLDER/ AAA/ .github/` returns **zero**. No `1.2.0` remains on the frozen-version line. `trug validate` on the edited reference TRUG returns VALID.

Pair-complete: the `tg`-vs-`trug`/`trug-a-folder` provenance is now honest across all TRUGS-AGENT doc surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)