### PR TITLE
docs(#3068 Appendix): drop PR-template check for never-published `create-trugs-agent`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,6 @@ Fixes #<!-- issue number, if applicable. For trivial chore/docs PRs, write "none
 <!-- What did you do to convince yourself this works? -->
 
 - [ ] `trug-a-folder check .` reports 0 errors
-- [ ] If installer changed: `create-trugs-agent` / `trugs-agent-init` produces the expected files in a scratch directory
 - [ ] If template changed: manually validated that an LLM (Claude Code / Cursor / Copilot) follows the updated instruction correctly
 - [ ] Manual check: <!-- describe -->
 


### PR DESCRIPTION
## What
`.github/PULL_REQUEST_TEMPLATE.md` test-plan checklist referenced `create-trugs-agent` / `trugs-agent-init` ("If installer changed: … produces the expected files"). **Neither command was ever published** (`README.md:109` admits it), so the check is vacuous — there is no installer to change. Removed the line.

## Why
#3068 Appendix (2026-07-13) item. #45 fixed the `tg check` line directly above this one but left the unpublished-installer reference (verified against `main`).

## Test plan
- [ ] PR template renders; no reference to nonexistent installer commands remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)